### PR TITLE
Fix getQueryResult to return table

### DIFF
--- a/src/ScribuntoLuaLibrary.php
+++ b/src/ScribuntoLuaLibrary.php
@@ -57,7 +57,7 @@ class ScribuntoLuaLibrary extends Scribunto_LuaLibraryBase {
 		$api->execute();
 		$data = $api->getResult()->getResultData();
 
-		return $data === null ? array( null ) : $data;
+		return $data === null ? array( null ) : array( $data );
 	}
 
 	/**

--- a/src/ScribuntoLuaLibrary.php
+++ b/src/ScribuntoLuaLibrary.php
@@ -57,7 +57,7 @@ class ScribuntoLuaLibrary extends Scribunto_LuaLibraryBase {
 		$api->execute();
 		$data = $api->getResult()->getResultData();
 
-		return $data === null ? array( null ) : array( $data );
+		return array( $data );
 	}
 
 	/**

--- a/tests/phpunit/Unit/mw.ext.smw.results.tests.lua
+++ b/tests/phpunit/Unit/mw.ext.smw.results.tests.lua
@@ -19,7 +19,9 @@ local tests = {
 	{ name = 'getQueryResult (meta count)',
 		func = function ( args )
 		  local ret =  mw.ext.smw.getQueryResult( args )
-		  return ret.printrequests[0].label
+		  for k,v in pairs(ret.query.printrequests ) do
+		      return v.label
+	  	  end
 		end,
 		args = { '[[Modification date::+]]|?Modification date|limit=0|mainlabel=-' },
 		expect = { 'Modification date' }


### PR DESCRIPTION
Wrap return value of getQueryResult in an array so that the entire result object will be transmitted.