### PR TITLE
Fix getQueryResult to return results in correct order

### DIFF
--- a/src/ScribuntoLuaLibrary.php
+++ b/src/ScribuntoLuaLibrary.php
@@ -56,7 +56,9 @@ class ScribuntoLuaLibrary extends Scribunto_LuaLibraryBase {
 		$api = new ApiMain( $params );
 		$api->execute();
 		$data = $api->getResult()->getResultData();
-
+		if(!empty($data) && !empty($data["query"]) && !empty($data["query"]["results"])) {
+			$data["query"]["results"] = array_combine(range(1, count($data["query"]["results"])), array_values($data["query"]["results"]));
+		}
 		return array( $data );
 	}
 

--- a/src/ScribuntoLuaLibrary.php
+++ b/src/ScribuntoLuaLibrary.php
@@ -56,7 +56,7 @@ class ScribuntoLuaLibrary extends Scribunto_LuaLibraryBase {
 		$api = new ApiMain( $params );
 		$api->execute();
 		$data = $api->getResult()->getResultData();
-		if(!empty($data) && !empty($data["query"]) && !empty($data["query"]["results"])) {
+		if(!empty($data["query"]["results"])) {
 			$data["query"]["results"] = array_combine(range(1, count($data["query"]["results"])), array_values($data["query"]["results"]));
 		}
 		return array( $data );


### PR DESCRIPTION
Change the results array to use integer keys rather than string keys. Using integer keys will guarantee that the result elements will remain in the correct order when the PHP array is converted into a Lua table.

See #5 