### PR TITLE
Remove mediawiki/scribunto temporarily

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,7 @@
 	"require": {
 		"php": ">=5.5",
 		"composer/installers": "1.*,>=1.0.1",
-		"mediawiki/semantic-media-wiki": "~2.3",
-		"mediawiki/scribunto": "*"
+		"mediawiki/semantic-media-wiki": "~2.3"
 	},
 	"require-dev": {
 		"mediawiki/semantic-media-wiki": "@dev",


### PR DESCRIPTION
The problem is that the `mediawiki/scribunto` doesn't contain any stable releases (you always have a `@dev...` release tag) because someone (in this case WMF) doesn't release software with a semver compliant versioning making dependent packages to define `dev` as minimum requirement which is somewhat counter productive in a production environment.