### PR TITLE
Adding mw.smw.subobject to available smw functions

### DIFF
--- a/src/ScribuntoLuaLibrary.php
+++ b/src/ScribuntoLuaLibrary.php
@@ -34,9 +34,10 @@ class ScribuntoLuaLibrary extends Scribunto_LuaLibraryBase {
 	public function register() {
 
 		$lib = array(
-			'getQueryResult'  => array( $this, 'getQueryResult' ),
 			'getPropertyType' => array( $this, 'getPropertyType' ),
+			'getQueryResult'  => array( $this, 'getQueryResult' ),
 			'set'             => array( $this, 'set' ),
+			'subobject'       => array( $this, 'subobject' ),
 		);
 
 		$this->getEngine()->registerInterface( __DIR__ . '/' . 'mw.smw.lua', $lib, array() );
@@ -107,6 +108,8 @@ class ScribuntoLuaLibrary extends Scribunto_LuaLibraryBase {
 	/**
 	 * This mirrors the functionality of the parser function #set and makes it available in lua.
 	 *
+	 * @since 1.0
+	 *
 	 * @param string|array	$parameters	parameters passed from lua, string or array depending on call
 	 *
 	 * @uses \SMW\ParserFunctionFactory::__construct, ParameterProcessorFactory::newFromArray
@@ -162,11 +165,82 @@ class ScribuntoLuaLibrary extends Scribunto_LuaLibraryBase {
 		}
 		$result = trim($result);
 
-		if ( strlen ($result) ) {
+		if ( is_string($result) && strlen ($result) ) {
 			# if result a non empty string, assume an error message
 			return array( [ 1 => false, self::SMW_ERROR_FIELD => preg_replace('/<[^>]+>/', '', $result) ] );
 		} else {
 			# on success, return true
+			return array( 1 => true );
+		}
+	}
+
+	/**
+	 * This mirrors the functionality of the parser function #subobject and makes it available to lua.
+	 *
+	 * @since 1.0
+	 *
+	 * @param string|array	$parameters     parameters passed from lua, string or array depending on call
+	 * @param string        $subobjectId    user provided subobject id
+	 *
+	 * @uses \SMW\ParserFunctionFactory::__construct, \SMW\ParameterProcessorFactory::newFromArray
+	 *
+	 * @return null|array|array[]
+	 */
+	public function subobject( $parameters, $subobjectId = null )
+	{
+		$parser = $this->getEngine()->getParser();
+
+		# make sure, we have an array of parameters
+		if ( !is_array($parameters) ) {
+			$parameters = array($parameters);
+		}
+
+		# if we have no arguments, do nothing
+		if ( !sizeof($parameters) || (sizeof($parameters) == 1 && !reset($parameters)) ) {
+			return null;
+		}
+
+		# lua starts arrays with 1, which is great, because parameters[0] would be the subobject id
+		if ( isset($parameters[0]) ) {
+			array_unshift($parameters, null);
+		}
+
+		# if subobject id was set, put it on position 0
+		if ( !is_null($subobjectId) && $subobjectId ) {
+			# user deliberately set an id for this subobject
+			$parameters[0] = $subobjectId;
+
+			# we need to ksort, otherwise ParameterProcessorFactory doesn't recognize the id
+			ksort($parameters);
+		}
+
+		# prepare subobjectParserFunction object
+		$parserFunctionFactory = new ParserFunctionFactory( $parser );
+		$subobjectParserFunction = $parserFunctionFactory->newSubobjectParserFunction( $parser );
+
+		# pre-process the parameters for the subobject
+		$processedParameter = ParameterProcessorFactory::newFromArray( $parameters );
+
+		$parserFunctionCallResult = $subobjectParserFunction->parse( $processedParameter );
+
+		# get result
+		if ( is_array($parserFunctionCallResult) ) {
+			$result = $parserFunctionCallResult[0];
+			$noParse = isset($parserFunctionCallResult['noparse']) ? $parserFunctionCallResult['noparse'] : true;
+		} else {
+			$result = $parserFunctionCallResult;
+			$noParse = true;
+		}
+
+		if ( ! $noParse ) {
+			$result = $parser->recursiveTagParseFully( $result );
+		}
+		$result = trim($result);
+
+		if ( is_string($result) && strlen($result) ) {
+			# this indicates an error
+			return array( [ 1 => false, self::SMW_ERROR_FIELD => preg_replace('/<[^>]+>/', '', $result) ] );
+		} else {
 			return array( 1 => true );
 		}
 	}

--- a/src/ScribuntoLuaLibrary.php
+++ b/src/ScribuntoLuaLibrary.php
@@ -111,7 +111,7 @@ class ScribuntoLuaLibrary extends Scribunto_LuaLibraryBase {
 	 *
 	 * @uses \SMW\ParserFunctionFactory::__construct, ParameterProcessorFactory::newFromArray
 	 *
-	 * @return array|array[]
+	 * @return null|array|array[]
 	 */
 	public function set( $parameters )
 	{
@@ -128,7 +128,15 @@ class ScribuntoLuaLibrary extends Scribunto_LuaLibraryBase {
 			if ( !is_int($key) && !preg_match('/[0-9]+/', $key) ) {
 				$value = $key . '=' . $value;
 			}
-			$argumentsToParserFunction[] = $value;
+			if ( $value ) {
+				# only add, when value is set. could be empty, if set was called with no parameter or empty string
+				$argumentsToParserFunction[] = $value;
+			}
+		}
+
+		# if we have no arguments, do nothing
+		if ( !sizeof($argumentsToParserFunction) ) {
+			return null;
 		}
 
 		# prepare setParserFunction object

--- a/src/mw.smw.lua
+++ b/src/mw.smw.lua
@@ -17,11 +17,11 @@ function smw.setupInterface()
 	php = mw_interface
 	mw_interface = nil
 
-	-- Register library within the "mw.ext.smw" namespace
+	-- Register library within the "mw.smw" namespace
 	mw = mw or {}
 	mw.smw = smw
 
-	package.loaded['mw.ext.smw'] = smw
+	package.loaded['mw.smw'] = smw
 end
 
 -- getQueryResult
@@ -34,6 +34,11 @@ end
 -- getPropertyType
 function smw.getPropertyType( name )
 	return php.getPropertyType( name )
+end
+
+-- set
+function smw.set( parameters )
+	return php.set( parameters )
 end
 
 return smw

--- a/src/mw.smw.lua
+++ b/src/mw.smw.lua
@@ -41,4 +41,9 @@ function smw.set( parameters )
 	return php.set( parameters )
 end
 
+-- subobject
+function smw.subobject( parameters, subobjectId )
+	return php.subobject( parameters, subobjectId )
+end
+
 return smw

--- a/tests/phpunit/Unit/ScribuntoLuaLibrarySetTest.php
+++ b/tests/phpunit/Unit/ScribuntoLuaLibrarySetTest.php
@@ -27,5 +27,4 @@ class ScribuntoLuaLibrarySetTest extends ScribuntoLuaEngineTestBase {
 			'SMW\Scribunto\Tests\ScribuntoLuaLibrarySetTest' => __DIR__ . '/' . 'mw.smw.set.tests.lua',
 		);
 	}
-	
 }

--- a/tests/phpunit/Unit/ScribuntoLuaLibrarySetTest.php
+++ b/tests/phpunit/Unit/ScribuntoLuaLibrarySetTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace SMW\Scribunto\Tests;
+
+/**
+ * @covers \SMW\Scribunto\ScribuntoLuaLibrary
+ * @group semantic-scribunto
+ *
+ * @license GNU GPL v2+
+ * @since 1.0
+ *
+ * @author oetterer
+ */
+class ScribuntoLuaLibrarySetTest extends ScribuntoLuaEngineTestBase {
+
+	/**
+	 * Lua test module
+	 * @var string
+	 */
+	protected static $moduleName = 'SMW\Scribunto\Tests\ScribuntoLuaLibrarySetTest';
+
+	/**
+	 * ScribuntoLuaEngineTestBase::getTestModules
+	 */
+	public function getTestModules() {
+		return parent::getTestModules() + array(
+			'SMW\Scribunto\Tests\ScribuntoLuaLibrarySetTest' => __DIR__ . '/' . 'mw.smw.set.tests.lua',
+		);
+	}
+	
+}

--- a/tests/phpunit/Unit/ScribuntoLuaLibrarySubobjectTest.php
+++ b/tests/phpunit/Unit/ScribuntoLuaLibrarySubobjectTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SMW\Scribunto\Tests;
+
+/**
+ * @covers \SMW\Scribunto\ScribuntoLuaLibrary
+ * @group semantic-scribunto
+ *
+ * @license GNU GPL v2+
+ * @since 1.0
+ *
+ * @author oetterer
+ */
+class ScribuntoLuaLibrarySubobjectTest extends ScribuntoLuaEngineTestBase {
+
+	/**
+	 * Lua test module
+	 * @var string
+	 */
+	protected static $moduleName = 'SMW\Scribunto\Tests\ScribuntoLuaLibrarySubobjectTest';
+
+	/**
+	 * ScribuntoLuaEngineTestBase::getTestModules
+	 */
+	public function getTestModules() {
+		return parent::getTestModules() + array(
+			'SMW\Scribunto\Tests\ScribuntoLuaLibrarySubobjectTest' => __DIR__ . '/' . 'mw.smw.subobject.tests.lua',
+		);
+	}
+}

--- a/tests/phpunit/Unit/mw.smw.set.tests.lua
+++ b/tests/phpunit/Unit/mw.smw.set.tests.lua
@@ -15,16 +15,17 @@ local tests = {
 		args = { '' },
 		expect = { nil }
 	},
-	{ name = 'set (matching input type to property type)', func = mw.smw.set,
-		args = { 'has type=page' },
+	{ name = 'set (matching input types to property types)', func = mw.smw.set,
+		args = { {'Has type=page', 'Allows value=test'} },
 		expect = { true }
 	},
 	{ name = 'set (supplying wrong input type to property type)', func = mw.smw.set,
-		args = { 'has type=test' },
+		args = { 'Has type=test' },
 		expect = {
 			{
 				false,
 				error = mw.message.new('smw_unknowntype'):inLanguage('en'):plain()
+				-- should be error = mw.message.new('smw_unknowntype'):inLanguage(mw.getContentLanguage()):plain()
 			}
 		}
 	},

--- a/tests/phpunit/Unit/mw.smw.set.tests.lua
+++ b/tests/phpunit/Unit/mw.smw.set.tests.lua
@@ -24,7 +24,7 @@ local tests = {
 		expect = {
 			{
 				false,
-				error = mw.message.new('smw_unknowntype'):plain()
+				error = mw.message.new('smw_unknowntype'):inLanguage(mw.getContentLanguage()):plain()
 			}
 		}
 	},

--- a/tests/phpunit/Unit/mw.smw.set.tests.lua
+++ b/tests/phpunit/Unit/mw.smw.set.tests.lua
@@ -1,0 +1,32 @@
+--[[
+	Tests for smw.property module
+
+	@since 0.1
+
+	@licence GNU GPL v2+
+	@author mwjames
+]]
+
+local testframework = require 'Module:TestFramework'
+
+-- Tests
+local tests = {
+	{ name = 'set (no argument)', func = mw.smw.set,
+		args = { '' },
+		expect = { nil }
+	},
+	{ name = 'set (matching input type to property type)', func = mw.smw.set,
+		args = { 'has type=page' },
+		expect = { true }
+	},
+	{ name = 'set (supplying wrong input type to property type)', func = mw.smw.set,
+		args = { 'has type=test' },
+		expect = { { false, mw.message.new('smw_unknowntype'):plain() } }
+	},
+	{ name = 'set (assigning data to non existing property)', func = mw.smw.set,
+		args = { '1215623e790d918773db943232068a93b21c9f1419cb85666c6558e87f5b7d47=test' },
+		expect = { true }
+	}
+}
+
+return testframework.getTestProvider( tests )

--- a/tests/phpunit/Unit/mw.smw.set.tests.lua
+++ b/tests/phpunit/Unit/mw.smw.set.tests.lua
@@ -21,7 +21,12 @@ local tests = {
 	},
 	{ name = 'set (supplying wrong input type to property type)', func = mw.smw.set,
 		args = { 'has type=test' },
-		expect = { { false, mw.message.new('smw_unknowntype'):plain() } }
+		expect = {
+			{
+				false,
+				error = mw.message.new('smw_unknowntype'):plain()
+			}
+		}
 	},
 	{ name = 'set (assigning data to non existing property)', func = mw.smw.set,
 		args = { '1215623e790d918773db943232068a93b21c9f1419cb85666c6558e87f5b7d47=test' },

--- a/tests/phpunit/Unit/mw.smw.set.tests.lua
+++ b/tests/phpunit/Unit/mw.smw.set.tests.lua
@@ -24,7 +24,7 @@ local tests = {
 		expect = {
 			{
 				false,
-				error = mw.message.new('smw_unknowntype'):inLanguage(mw.getContentLanguage()):plain()
+				error = mw.message.new('smw_unknowntype'):inLanguage('en'):plain()
 			}
 		}
 	},

--- a/tests/phpunit/Unit/mw.smw.subobject.tests.lua
+++ b/tests/phpunit/Unit/mw.smw.subobject.tests.lua
@@ -1,0 +1,62 @@
+--[[
+	Tests for smw.property module
+
+	@since 0.1
+
+	@licence GNU GPL v2+
+	@author mwjames
+]]
+
+local testframework = require 'Module:TestFramework'
+
+-- Tests
+local tests = {
+	{ name = 'subobject (no argument)', func = mw.smw.subobject,
+		args = { '' },
+		expect = { nil }
+	},
+	{ name = 'subobject (matching input types to property types)', func = mw.smw.subobject,
+		args = { {'Has type=page', 'Allows value=test'} },
+		expect = { true }
+	},
+
+	{ name = 'subobject (supplying a wrong input type to property type)', func = mw.smw.subobject,
+		args = { {'Has type=test', 'Allows value=test'} },
+		expect = {
+			{
+				false,
+				error = mw.message.new('smw_unknowntype'):inLanguage('en'):plain()
+				-- should be error = mw.message.new('smw_unknowntype'):inLanguage(mw.getContentLanguage()):plain()
+			}
+		}
+	},
+	{ name = 'subobject (assigning data to non existing property)', func = mw.smw.subobject,
+		args = { {'Has type=page', 'Allows value=test' , '1215623e790d918773db943232068a93b21c9f1419cb85666c6558e87f5b7d47=test'} },
+		expect = { true }
+	},
+	{ name = 'subobject (no argument, supplying id)', func = mw.smw.subobject,
+		args = { {}, '0123456780_teststringAsId' },
+		expect = { nil }
+	},
+	{ name = 'subobject (matching input types to property types, supplying id)', func = mw.smw.subobject,
+		args = { {'Has type=page', 'Allows value=test'}, '0123456780_teststringAsId' },
+		expect = { true }
+	},
+
+	{ name = 'subobject (supplying a wrong input type to property type, supplying id)', func = mw.smw.subobject,
+		args = { {'Has type=test', 'Allows value=test'}, '0123456780_teststringAsId' },
+		expect = {
+			{
+				false,
+				error = mw.message.new('smw_unknowntype'):inLanguage('en'):plain()
+				-- should be error = mw.message.new('smw_unknowntype'):inLanguage(mw.getContentLanguage()):plain()
+			}
+		}
+	},
+	{ name = 'subobject (assigning data to non existing property, supplying id)', func = mw.smw.subobject,
+		args = { {'Has type=page', 'Allows value=test' , '1215623e790d918773db943232068a93b21c9f1419cb85666c6558e87f5b7d47=test'}, '0123456780_teststringAsId' },
+		expect = { true }
+	},
+}
+
+return testframework.getTestProvider( tests )


### PR DESCRIPTION
Here comes the smw parser function "subobject" to the available lua functions.

I'm not sure, if I should have branched before my previous PR, since this now includes both. Sry for the mess...

Nevertheless. Againg, the implementation re-uses as much code as possible from the smw parser function call. It utilizes class ParserFunctionFactory to get the same kind of object, the normal parser function call to #subobject would use. It then defers parameter processing and the semantic storage process to this object the same way a normal parser function call would use.

Difference to the parser function call is:

- it does a preliminary argument processing to catch multiple input formats and some lua specific
peculiarities
- it aborts on empty parameters
- it returns true on success and an array containing the error message in case of failure/warnings
