### PR TITLE
Adding mw.smw.info to available smw functions

### DIFF
--- a/src/ScribuntoLuaLibrary.php
+++ b/src/ScribuntoLuaLibrary.php
@@ -111,7 +111,7 @@ class ScribuntoLuaLibrary extends Scribunto_LuaLibraryBase {
 	 *
 	 * @uses \SMW\ParserFunctionFactory::__construct, ParameterProcessorFactory::newFromArray
 	 *
-	 * @return array|array[]
+	 * @return null|array|array[]
 	 */
 	public function set( $parameters )
 	{
@@ -128,7 +128,15 @@ class ScribuntoLuaLibrary extends Scribunto_LuaLibraryBase {
 			if ( !is_int($key) && !preg_match('/[0-9]+/', $key) ) {
 				$value = $key . '=' . $value;
 			}
-			$argumentsToParserFunction[] = $value;
+			if ( $value ) {
+				# only add, when value is set. could be empty, if set was called with no parameter or empty string
+				$argumentsToParserFunction[] = $value;
+			}
+		}
+
+		# if we have no arguments, do nothing
+		if ( !sizeof($argumentsToParserFunction) ) {
+			return null;
 		}
 
 		# prepare setParserFunction object

--- a/src/mw.smw.lua
+++ b/src/mw.smw.lua
@@ -17,11 +17,11 @@ function smw.setupInterface()
 	php = mw_interface
 	mw_interface = nil
 
-	-- Register library within the "mw.ext.smw" namespace
+	-- Register library within the "mw.smw" namespace
 	mw = mw or {}
 	mw.smw = smw
 
-	package.loaded['mw.ext.smw'] = smw
+	package.loaded['mw.smw'] = smw
 end
 
 -- getQueryResult
@@ -34,6 +34,11 @@ end
 -- getPropertyType
 function smw.getPropertyType( name )
 	return php.getPropertyType( name )
+end
+
+-- set
+function smw.set( parameters )
+	return php.set( parameters )
 end
 
 return smw

--- a/src/mw.smw.lua
+++ b/src/mw.smw.lua
@@ -36,6 +36,11 @@ function smw.getPropertyType( name )
 	return php.getPropertyType( name )
 end
 
+-- info
+function smw.info( text, icon )
+	return php.info( text, icon )
+end
+
 -- set
 function smw.set( parameters )
 	return php.set( parameters )

--- a/tests/phpunit/Unit/ScribuntoLuaLibraryInfoTest.php
+++ b/tests/phpunit/Unit/ScribuntoLuaLibraryInfoTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SMW\Scribunto\Tests;
+
+/**
+ * @covers \SMW\Scribunto\ScribuntoLuaLibrary
+ * @group semantic-scribunto
+ *
+ * @license GNU GPL v2+
+ * @since 1.0
+ *
+ * @author oetterer
+ */
+class ScribuntoLuaLibraryInfoTest extends ScribuntoLuaEngineTestBase {
+
+	/**
+	 * Lua test module
+	 * @var string
+	 */
+	protected static $moduleName = 'SMW\Scribunto\Tests\ScribuntoLuaLibraryInfoTest';
+
+	/**
+	 * ScribuntoLuaEngineTestBase::getTestModules
+	 */
+	public function getTestModules() {
+		return parent::getTestModules() + array(
+			'SMW\Scribunto\Tests\ScribuntoLuaLibraryInfoTest' => __DIR__ . '/' . 'mw.smw.info.tests.lua',
+		);
+	}
+}

--- a/tests/phpunit/Unit/ScribuntoLuaLibraryInfoTest.php
+++ b/tests/phpunit/Unit/ScribuntoLuaLibraryInfoTest.php
@@ -17,14 +17,14 @@ class ScribuntoLuaLibraryInfoTest extends ScribuntoLuaEngineTestBase {
 	 * Lua test module
 	 * @var string
 	 */
-	protected static $moduleName = 'SMW\Scribunto\Tests\ScribuntoLuaLibraryInfoTest';
+	protected static $moduleName = self::class;
 
 	/**
 	 * ScribuntoLuaEngineTestBase::getTestModules
 	 */
 	public function getTestModules() {
 		return parent::getTestModules() + array(
-			'SMW\Scribunto\Tests\ScribuntoLuaLibraryInfoTest' => __DIR__ . '/' . 'mw.smw.info.tests.lua',
+			self::$moduleName => __DIR__ . '/' . 'mw.smw.info.tests.lua',
 		);
 	}
 }

--- a/tests/phpunit/Unit/ScribuntoLuaLibrarySetTest.php
+++ b/tests/phpunit/Unit/ScribuntoLuaLibrarySetTest.php
@@ -27,5 +27,4 @@ class ScribuntoLuaLibrarySetTest extends ScribuntoLuaEngineTestBase {
 			'SMW\Scribunto\Tests\ScribuntoLuaLibrarySetTest' => __DIR__ . '/' . 'mw.smw.set.tests.lua',
 		);
 	}
-	
 }

--- a/tests/phpunit/Unit/ScribuntoLuaLibrarySetTest.php
+++ b/tests/phpunit/Unit/ScribuntoLuaLibrarySetTest.php
@@ -17,14 +17,14 @@ class ScribuntoLuaLibrarySetTest extends ScribuntoLuaEngineTestBase {
 	 * Lua test module
 	 * @var string
 	 */
-	protected static $moduleName = 'SMW\Scribunto\Tests\ScribuntoLuaLibrarySetTest';
+	protected static $moduleName = self::class;
 
 	/**
 	 * ScribuntoLuaEngineTestBase::getTestModules
 	 */
 	public function getTestModules() {
 		return parent::getTestModules() + array(
-			'SMW\Scribunto\Tests\ScribuntoLuaLibrarySetTest' => __DIR__ . '/' . 'mw.smw.set.tests.lua',
+			self::$moduleName => __DIR__ . '/' . 'mw.smw.set.tests.lua',
 		);
 	}
 }

--- a/tests/phpunit/Unit/ScribuntoLuaLibrarySetTest.php
+++ b/tests/phpunit/Unit/ScribuntoLuaLibrarySetTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace SMW\Scribunto\Tests;
+
+/**
+ * @covers \SMW\Scribunto\ScribuntoLuaLibrary
+ * @group semantic-scribunto
+ *
+ * @license GNU GPL v2+
+ * @since 1.0
+ *
+ * @author oetterer
+ */
+class ScribuntoLuaLibrarySetTest extends ScribuntoLuaEngineTestBase {
+
+	/**
+	 * Lua test module
+	 * @var string
+	 */
+	protected static $moduleName = 'SMW\Scribunto\Tests\ScribuntoLuaLibrarySetTest';
+
+	/**
+	 * ScribuntoLuaEngineTestBase::getTestModules
+	 */
+	public function getTestModules() {
+		return parent::getTestModules() + array(
+			'SMW\Scribunto\Tests\ScribuntoLuaLibrarySetTest' => __DIR__ . '/' . 'mw.smw.set.tests.lua',
+		);
+	}
+	
+}

--- a/tests/phpunit/Unit/mw.smw.info.tests.lua
+++ b/tests/phpunit/Unit/mw.smw.info.tests.lua
@@ -1,0 +1,44 @@
+--[[
+	Tests for smw.info module
+
+	@since 1.0
+
+	@licence GNU GPL v2+
+	@author oetterer
+]]
+
+local testframework = require 'Module:TestFramework'
+
+-- Tests
+local tests = {
+	{ name = 'info (no argument)', func = mw.smw.info,
+		args = { '' },
+		expect = { nil }
+	},
+	{ name = 'info (text, no icon)',
+		func = function ( args )
+			local ret = mw.smw.info( args )
+			return type(ret), #ret > 0
+		end,
+		args = { 'Infotext' },
+		expect = { 'string', true }
+	},
+	{ name = 'info (text, valid icon)',
+		func = function ( args )
+			local ret = mw.smw.info( args )
+			return type(ret), #ret > 0
+		end,
+		args = { 'Infotext', 'note' },
+		expect = { 'string', true }
+	},
+	{ name = 'info (text, invalid icon)',
+		func = function ( args )
+			local ret = mw.smw.info( args )
+			return type(ret), #ret > 0
+		end,
+		args = { 'Infotext', 'test' },
+		expect = { 'string', true }
+	}
+}
+
+return testframework.getTestProvider( tests )

--- a/tests/phpunit/Unit/mw.smw.set.tests.lua
+++ b/tests/phpunit/Unit/mw.smw.set.tests.lua
@@ -24,7 +24,7 @@ local tests = {
 		expect = {
 			{
 				false,
-				error = mw.message.new('smw_unknowntype'):plain()
+				error = mw.message.new('smw_unknowntype'):inLanguage(mw.getContentLanguage()):plain()
 			}
 		}
 	},

--- a/tests/phpunit/Unit/mw.smw.set.tests.lua
+++ b/tests/phpunit/Unit/mw.smw.set.tests.lua
@@ -1,0 +1,32 @@
+--[[
+	Tests for smw.property module
+
+	@since 0.1
+
+	@licence GNU GPL v2+
+	@author mwjames
+]]
+
+local testframework = require 'Module:TestFramework'
+
+-- Tests
+local tests = {
+	{ name = 'set (no argument)', func = mw.smw.set,
+		args = { '' },
+		expect = { nil }
+	},
+	{ name = 'set (matching input type to property type)', func = mw.smw.set,
+		args = { 'has type=page' },
+		expect = { true }
+	},
+	{ name = 'set (supplying wrong input type to property type)', func = mw.smw.set,
+		args = { 'has type=test' },
+		expect = { { false, mw.message.new('smw_unknowntype'):plain() } }
+	},
+	{ name = 'set (assigning data to non existing property)', func = mw.smw.set,
+		args = { '1215623e790d918773db943232068a93b21c9f1419cb85666c6558e87f5b7d47=test' },
+		expect = { true }
+	}
+}
+
+return testframework.getTestProvider( tests )

--- a/tests/phpunit/Unit/mw.smw.set.tests.lua
+++ b/tests/phpunit/Unit/mw.smw.set.tests.lua
@@ -21,7 +21,12 @@ local tests = {
 	},
 	{ name = 'set (supplying wrong input type to property type)', func = mw.smw.set,
 		args = { 'has type=test' },
-		expect = { { false, mw.message.new('smw_unknowntype'):plain() } }
+		expect = {
+			{
+				false,
+				error = mw.message.new('smw_unknowntype'):plain()
+			}
+		}
 	},
 	{ name = 'set (assigning data to non existing property)', func = mw.smw.set,
 		args = { '1215623e790d918773db943232068a93b21c9f1419cb85666c6558e87f5b7d47=test' },

--- a/tests/phpunit/Unit/mw.smw.set.tests.lua
+++ b/tests/phpunit/Unit/mw.smw.set.tests.lua
@@ -1,10 +1,10 @@
 --[[
-	Tests for smw.property module
+	Tests for smw.set module
 
-	@since 0.1
+	@since 1.0
 
 	@licence GNU GPL v2+
-	@author mwjames
+	@author oetterer
 ]]
 
 local testframework = require 'Module:TestFramework'

--- a/tests/phpunit/Unit/mw.smw.set.tests.lua
+++ b/tests/phpunit/Unit/mw.smw.set.tests.lua
@@ -24,7 +24,7 @@ local tests = {
 		expect = {
 			{
 				false,
-				error = mw.message.new('smw_unknowntype'):inLanguage(mw.getContentLanguage()):plain()
+				error = mw.message.new('smw_unknowntype'):inLanguage('en'):plain()
 			}
 		}
 	},


### PR DESCRIPTION
Soo, this time with a branch. not sure, this is better, though. This will be my last PR for today.

This one follows a slightly different path. To remove the usage of `\ParserHooks\FunctionRunner`, the contents of `InfoParserFunction`'s `handle` have been replicated. That meant, also doing the parameter verification in the new function. Fortunately `#ino` is lightweight and not that complicated.