### PR TITLE
this adds the parser function subobject and provides a new test suite…

### DIFF
--- a/SemanticScribunto.php
+++ b/SemanticScribunto.php
@@ -42,7 +42,10 @@ class SemanticScribunto {
 		$GLOBALS['wgExtensionCredits']['semantic'][] = array(
 			'path'           => __FILE__,
 			'name'           => 'Semantic Scribunto',
-			'author'         => array( 'James Hong Kong' ),
+			'author'         => array(
+				'James Hong Kong',
+				'[https://www.semantic-mediawiki.org/wiki/User:Oetterer Tobias Oetterer]',
+			),
 			'url'            => 'https://github.com/SemanticMediaWiki/SemanticScribunto/',
 			'descriptionmsg' => 'smw-scribunto-desc',
 			'version'        => SMW_SCRIBUNTO_VERSION,

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -32,7 +32,7 @@ function p.ask(frame)
         return "no parameter found"
     end
     
-    local queryResult = mw.smw.getQueryResult( frame.args[1] )
+    local queryResult = mw.smw.getQueryResult( frame.args )
 
     if queryResult == nil then
         return "(no values)"
@@ -41,7 +41,11 @@ function p.ask(frame)
     if type( queryResult ) == "table" then
         local myResult = ""
         for k,v in pairs( queryResult.results ) do
-            myResult = myResult .. k .. " | " .. v.fulltext .. " " .. v.fullurl .. " | " .. "<br/>"
+            if  v.fulltext and v.fullurl then
+                myResult = myResult .. k .. " | " .. v.fulltext .. " " .. v.fullurl .. " | " .. "<br/>"
+            else
+                myResult = myResult .. k .. " | no page title for result set available (you probably specified ''mainlabel=-')"
+            end
         end
         return myResult
     end
@@ -51,6 +55,7 @@ end
 
 return p
 ```
+
 The return format matches the data structure delivered by the [api]. You can see an example below:
 ```lua
 -- assuming sample call

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -1,12 +1,22 @@
 ## mw.smw library functions
 
-The following functions are available:
+
+### overview
+The following functions are available through the `mw.smw` package:
 
 - [`mw.smw.getQueryResult`](#mw.smw.getQueryResult)
 - [`mw.smw.getPropertyType`](#mw.smw.getPropertyType)
+- [`mw.smw.info`](#mw.smw.info)
+- [`mw.smw.set`](#mw.smw.set)
+- [`mw.smw.subobject`](#mw.smw.subobject)
 
-### mw.smw.getQueryResult
+### data retrieval functions
+#### mw.smw.getQueryResult
 
+With `mw.smw.getQueryResult` you can execute an smw query. It returns the result as a lua table for direct use in modules.
+For available parameters, please consult the [Semantic Media Wiki documentation hub][smwdoc].
+
+This is a sample call:
 ```lua
 -- Module:SMW
 local p = {}
@@ -20,16 +30,16 @@ function p.ask(frame)
 
     if frame.args[1] == nil then
         return "no parameter found"
-    else
-        queryResult = mw.smw.getQueryResult( frame.args[1] )
     end
+    
+    local queryResult = mw.smw.getQueryResult( frame.args[1] )
 
     if queryResult == nil then
         return "(no values)"
     end
 
     if type( queryResult ) == "table" then
-        myResult = ""
+        local myResult = ""
         for k,v in pairs( queryResult.results ) do
             myResult = myResult .. k .. " | " .. v.fulltext .. " " .. v.fullurl .. " | " .. "<br/>"
         end
@@ -38,14 +48,104 @@ function p.ask(frame)
 
     return queryResult
 end
+
+return p
+```
+The return format matches the data structure delivered by the [api]. You can see an example below:
+```lua
+-- assuming sample call
+local result = mw.smw.getQueryResult( '[[Modification date::+]]|?Modification date|?Last editor is|limit=2|mainlabel=page' )
+-- your result would look something like
+{
+    printrequests = {
+        {
+            label = 'page',
+            redi = null,
+            typeid = '_wpg',
+            mode = 2,
+            format = null
+        },
+        {
+            label = 'Modification date',
+            key = '_MDAT',
+            redi = null,
+            typeid = '_dat',
+            mode = 1,
+            format = null
+        },
+        {
+            label = 'editor',
+            key = '_LEDT',
+            redi = null,
+            typeid = '_wpg',
+            mode = 1,
+            format = null
+        },
+    },
+    result = {
+        {
+            printouts = {
+                ['Modification date'] = {
+                    {
+                        timestamp = 123456789, -- a unix timestamp
+                        raw = '1/1970/1/1/23/59/59/0'
+                    }
+                },
+                editor = {
+                    {
+                        fulltext = 'User:Mwjames',
+                        fullurl = 'https://your.host/w/User:Mwjames'
+                    }
+                }
+            },
+            fulltext = 'Main page',
+            fullurl = 'https://your.host/w/Main_page',
+            namespace = 0,
+            exist = 1,
+            displaytitle = ''
+        },
+        {
+            printouts = {
+                ['Modification date'] = {
+                    {
+                        timestamp = 123456790, -- a unix timestamp
+                        raw = '1/1970/1/2/0/0/1/0'
+                    }
+                },
+                editor = {
+                    {
+                        fulltext = 'User:Matthew-a-thompson',
+                        fullurl = 'https://your.host/w/User:Matthew-a-thompson'
+                    }
+                }
+            },
+            fulltext = 'User:Matthew A Thompson',
+            fullurl = 'https://your.host/w/User:Matthew_A_Thompson',
+            namespace = 2,
+            exist = 1,
+            displaytitle = ''
+        },
+    },
+    serializer = 'SMW\Serializers\QueryResultSerializer',
+    version = 0.11,
+    meta = {
+        hash = '5b2187c3df541ca08d378b3690a31173',
+        count = 2,  -- number of results
+        offset = 0, -- used offset
+        source = null,
+        time = 0.000026,
+    }
+}
 ```
 
 Calling `{{#invoke:smw|ask|[[Modification date::+]]|?Modification date|limit=0|mainlabel=-}}` only
 makes sense in a template or another module that can handle `table` return values.
 
-### mw.smw.getPropertyType
+#### mw.smw.getPropertyType
+The function `mw.smw.getPropertyType` provides an easy way to get the type of a given property.
+Note however, that it uses the smw internal property types, not the one you might be [used to](https://www.semantic-mediawiki.org/wiki/Help:List_of_datatypes).
 
-```
+```lua
 -- Module:SMW
 local p = {}
 
@@ -58,15 +158,14 @@ function p.type(frame)
 
     if frame.args[1] == nil then
         return "no parameter found"
-    else
-        type = mw.smw.getPropertyType( frame.args[1] )
     end
+    local pType = mw.smw.getPropertyType( frame.args[1] )
 
-    if type == nil then
+    if pType == nil then
         return "(no values)"
     end
 
-    return type
+    return pType
 end
 
 return p
@@ -74,8 +173,202 @@ return p
 
 `{{#invoke:smw|type|Modification date}}` can be used as it returns a simple string value such as `_dat`.
 
+### data storage functions
+#### mw.smw.set
+This makes the smw parser function `#set` available in lua and allows you to store data in your smw store.
+The usage is similar to that of the [parser function][set], however be advised to read the notes under the example.
+
+This is a sample call:
+```lua
+-- Module:SMW
+local p = {}
+
+-- set with return results
+function p.set( frame )
+
+    if not mw.smw then
+        return "mw.smw module not found"
+    end
+    
+    if #frame.args == 0 then
+        return "no parameters found"
+    end
+    local result = mw.smw.set( frame.args )
+    if result == true then
+        return 'Your data was stored successfully'
+    else
+        return 'An error occurred during the storage process. Message reads ' .. result.error
+    end
+end
+
+-- another example, set used inside another function
+function p.inlineSet( frame )
+
+    local dataStoreTyp1 = {}
+    
+    dataStoreTyp1['my property1'] = 'value1'
+    dataStoreTyp1['my property2'] = 'value2'
+    dataStoreTyp1['my property3'] = 'value3'
+    
+    local result = mw.smw.set( dataStoreTyp1 )
+    
+    if result == true then
+        -- everything ok
+    else
+        -- error message to be found in result.error
+    end
+    
+    local dataStoreType2 = {
+        'my property1=value1',
+        'my property2=value2',
+        'my property3=value3',
+    }
+    
+    local result = mw.smw.set( dataStoreType2 )
+    
+    if result == true then
+        -- everything ok
+    else
+        -- error message to be found in result.error
+    end
+end
+
+return p
+```
+As you can see, you can supply arguments to `mw.smw.set` as either an associative array and as lua table.
+
+**Note** however: lua does not maintain the order in an associative array. Using parameters for `set` like the [separator](https://www.semantic-mediawiki.org/wiki/Help:Setting_values/Working_with_the_separator_parameter)
+or the [template parameter](https://www.semantic-mediawiki.org/wiki/Help:Setting_values/Working_with_the_template_parameter) requires a strict parameter order
+in which case you must use the table format as shown with *dataStoreType2* in the example above.
+
+
+SMW.set can be invoked via `{{#invoke:smw|set|my property1=value1|my property2=value2}}`. However, using the lua function in this way makes little sense.
+It is designed to be used inside your modules.
+
+#### mw.smw.subobject
+This makes the smw parser function `#subobject` available in lua and allows you to store data in your smw store as subobjects.
+The usage is similar to that of the [parser function][subobject] but be advised to read the notes for [mw.smw.info](#mw.smw.info) as well.
+
+This is a sample call:
+```lua
+-- Module:SMW
+local p = {}
+
+-- subobject with return results
+function p.subobject( frame )
+
+    if not mw.smw then
+        return "mw.smw module not found"
+    end
+    
+    if #frame.args == 0 then
+        return "no parameters found"
+    end
+    local result = mw.smw.subobject( frame.args )
+    if result == true then
+        return 'Your data was stored successfully in a subobject'
+    else
+        return 'An error occurred during the subobject storage process. Message reads ' .. result.error
+    end
+end
+-- another example, subobject used inside another function
+function p.inlineSubobject( frame )
+
+    local dataStoreTyp1 = {}
+    
+    dataStoreTyp1['my property1'] = 'value1'
+    dataStoreTyp1['my property2'] = 'value2'
+    dataStoreTyp1['my property3'] = 'value3'
+    
+    local result = mw.smw.subobject( dataStoreTyp1 )
+    
+    if result == true then
+        -- everything ok
+    else
+        -- error message to be found in result.error
+    end
+    
+    local dataStoreType2 = {
+        'my property1=value1',
+        'my property2=value2',
+        'my property3=value3',
+    }
+    
+    local result = mw.smw.subobject( dataStoreType2 )
+    
+    if result == true then
+        -- everything ok
+    else
+        -- error message to be found in result.error
+    end
+    
+    -- you can also manually set a subobject id. however, this is not recommended
+    
+    local result = mw.smw.subobject( dataStoreType2, 'myPersonalId' )
+    if result == true then
+        -- everything ok
+    else
+        -- error message to be found in result.error
+    end    
+end
+
+return p
+```
+
+### miscellaneous
+#### mw.smw.info
+This makes the smw parser function `#info` available in lua and allows you to add tooltips to your output stream. See [the documentation on the SMW homepage][info] for more information.
+
+This is a sample call:
+```lua
+-- Module:SMW
+local p = {}
+
+-- set with direct return results
+function p.info( frame )
+
+    if not mw.smw then
+        return "mw.smw module not found"
+    end
+
+    if frame.args[1] == nil then
+        return "no parameter found"
+    end
+    
+    local tooltip
+    if frame.args[2] then
+        tooltip = mw.smw.info( frame.args[1], frame.args[2] )
+    else
+        tooltip = mw.smw.info( frame.args[1] )
+    end
+
+    return tooltip
+end
+-- another example, info used inside another function
+function p.inlineInfo( frame )
+
+    local output = 'This is sample output'
+    
+    -- so some stuff
+    
+    output = output .. mw.smw.info( 'This is a warning', 'warning' )
+    
+    -- some more stuff
+    
+    return output
+end
+
+return p
+```
+
+### notes
 ## Using #invoke
 
 For a detailed description about the `#invoke`, please have a look at the [Lua reference][lua] manual.
 
 [lua]: https://www.mediawiki.org/wiki/Extension:Scribunto/Lua_reference_manual
+[api]: https://www.semantic-mediawiki.org/wiki/Serialization_%28JSON%29
+[smwdoc]: https://www.semantic-mediawiki.org/wiki/Semantic_MediaWiki
+[set]: https://www.semantic-mediawiki.org/wiki/Help:Setting_values
+[subobject]: https://www.semantic-mediawiki.org/wiki/Help:Adding_subobjects
+[info]: https://www.semantic-mediawiki.org/wiki/Help:Adding_tooltips

--- a/src/ScribuntoLuaLibrary.php
+++ b/src/ScribuntoLuaLibrary.php
@@ -48,13 +48,13 @@ class ScribuntoLuaLibrary extends Scribunto_LuaLibraryBase {
 	 *
 	 * @since 1.0
 	 *
-	 * @param string $argString
+	 * @param string|array $arguments
 	 *
 	 * @return array
 	 */
-	public function getQueryResult( $argString = null ) {
+	public function getQueryResult( $arguments = null ) {
 
-		$rawParameters = preg_split( "/(?<=[^\|])\|(?=[^\|])/", $argString );
+		$rawParameters = $this->processLuaArguments( $arguments );
 
 		list( $queryString, $parameters, $printouts ) = QueryProcessor::getComponentsFromFunctionParams(
 		    $rawParameters,
@@ -143,7 +143,7 @@ class ScribuntoLuaLibrary extends Scribunto_LuaLibraryBase {
 		// to have all necessary data committed to output, use SMWOutputs::commitToParser()
 		SMWOutputs::commitToParser( $parser );
 
-		return array( $this->extractResultString( $result ) );
+		return array( $this->getParsedResult( $result ) );
 	}
 
 	/**
@@ -176,7 +176,7 @@ class ScribuntoLuaLibrary extends Scribunto_LuaLibraryBase {
 		);
 
 		// get usable result
-		$result = $this->extractResultString( $parserFunctionCallResult );
+		$result = $this->getParsedResult( $parserFunctionCallResult );
 
 		if ( strlen( $result ) ) {
 			// if result a non empty string, assume an error message
@@ -229,7 +229,7 @@ class ScribuntoLuaLibrary extends Scribunto_LuaLibraryBase {
 
 		$parserFunctionCallResult = $subobjectParserFunction->parse( $processedParameter );
 
-		if ( strlen( $result = $this->extractResultString( $parserFunctionCallResult ) ) ) {
+		if ( strlen( $result = $this->getParsedResult( $parserFunctionCallResult ) ) ) {
 			// if result a non empty string, assume an error message
 			return array( [ 1 => false, self::SMW_ERROR_FIELD => preg_replace( '/<[^>]+>/', '', $result ) ] );
 		} else {
@@ -247,7 +247,7 @@ class ScribuntoLuaLibrary extends Scribunto_LuaLibraryBase {
 	 *
 	 * @return string
 	 */
-	private function extractResultString( $parserFunctionResult ) {
+	private function getParsedResult( $parserFunctionResult ) {
 
 		// parser function call can return string or array
 		if ( is_array( $parserFunctionResult ) ) {
@@ -278,7 +278,7 @@ class ScribuntoLuaLibrary extends Scribunto_LuaLibraryBase {
 
 		// make sure, we have an array of parameters
 		if ( !is_array( $arguments ) ) {
-			$arguments = array( $arguments );
+			$arguments = preg_split( "/(?<=[^\|])\|(?=[^\|])/", $arguments );
 		}
 
 		// if $arguments were supplied as key => value pair (aka associative array), we rectify this here

--- a/src/mw.smw.lua
+++ b/src/mw.smw.lua
@@ -47,4 +47,9 @@ function smw.set( parameters )
 	return php.set( parameters )
 end
 
+-- subobject
+function smw.subobject( parameters, subobjectId )
+	return php.subobject( parameters, subobjectId )
+end
+
 return smw

--- a/tests/phpunit/Unit/ScribuntoLuaLibraryTest.php
+++ b/tests/phpunit/Unit/ScribuntoLuaLibraryTest.php
@@ -120,6 +120,10 @@ class ScribuntoLuaLibraryTest extends \Scribunto_LuaEngineTestBase {
 			'Modification date',
 			$this->scribuntoLuaLibrary->getQueryResult( '[[Modification date::+]]|?Modification date|limit=0|mainlabel=-' )[0]['printrequests'][0]['label']
 		);
+		$this->assertEquals(
+			'Modification date',
+			$this->scribuntoLuaLibrary->getQueryResult( [ '[[Modification date::+]]', '?Modification date', 'limit' => 0, 'mainlabel=-' ] )[0]['printrequests'][0]['label']
+		);
 	}
 
 	/**
@@ -233,6 +237,10 @@ class ScribuntoLuaLibraryTest extends \Scribunto_LuaEngineTestBase {
 			[
 				[ '1215623e790d918773db943232068a93b21c9f1419cb85666c6558e87f5b7d47=test' ],
 				[ 1 => true ]
+			],
+			[
+				[ '1215623e790d918773db943232068a93b21c9f1419cb85666c6558e87f5b7d47=test', 'foo' => 'bar' ],
+				[ 1 => true ]
 			]
 		);
 
@@ -294,7 +302,7 @@ class ScribuntoLuaLibraryTest extends \Scribunto_LuaEngineTestBase {
 				[ array( 1 => false, 'error' => wfMessage('smw_unknowntype')->inLanguage('en')->plain() ) ]
 			],
 			[
-				[ [ 'has type=page', 'Allows value=test','1215623e790d918773db943232068a93b21c9f1419cb85666c6558e87f5b7d47=test' ], '01234567890_testStringAsId' ],
+				[ [ 'has type=page', 'Allows value' => 'test','1215623e790d918773db943232068a93b21c9f1419cb85666c6558e87f5b7d47=test' ], '01234567890_testStringAsId' ],
 				[ 1 => true ]
 			],
 		);

--- a/tests/phpunit/Unit/ScribuntoLuaLibraryTest.php
+++ b/tests/phpunit/Unit/ScribuntoLuaLibraryTest.php
@@ -1,0 +1,304 @@
+<?php
+
+namespace SMW\Scribunto\Tests;
+
+use SMW\Scribunto\ScribuntoLuaLibrary;
+
+/**
+ * @covers \SMW\Scribunto\ScribuntoLuaLibrary
+ *
+ * @license GNU GPL v2+
+ * @since 1.0
+ *
+ * @author oetterer
+ */
+class ScribuntoLuaLibraryTest extends \Scribunto_LuaEngineTestBase {
+
+	/**
+	 * @var \SMW\Scribunto\ScribuntoLuaLibrary
+	 */
+	protected $scribuntoLuaLibrary;
+
+	/**
+	 * Lua test module
+	 * @var string
+	 */
+	protected static $moduleName = self::class;
+
+	/**
+	 * ScribuntoLuaEngineTestBase::getTestModules
+	 */
+	public function getTestModules() {
+		return parent::getTestModules() + array(
+			self::$moduleName => __DIR__ . '/' . 'mw.smw.tests.lua',
+		);
+	}
+
+	protected function setUp() {
+		parent::setUp();
+
+		/** @noinspection PhpParamsInspection */
+		$this->scribuntoLuaLibrary = new ScribuntoLuaLibrary(
+			$this->getEngine()
+		);
+	}
+
+	public function testCanConstruct() {
+		$this->assertInstanceOf(
+			'\SMW\Scribunto\ScribuntoLuaLibrary',
+			$this->scribuntoLuaLibrary
+		);
+	}
+
+	/**
+	 * Test, if all the necessary methods exists. Uses data provider {@see dataProviderFunctionTest}
+	 * @dataProvider dataProviderFunctionTest
+	 *
+	 * @param string $method name of method to check
+	 *
+	 * @used \SMW\Scribunto\Tests\ScribuntoLuaLibraryTest::dataProviderFunctionTest
+	 *
+	 * @return void
+	 */
+	public function testMethodsExist( $method ) {
+		$this->assertTrue(
+			method_exists( $this->scribuntoLuaLibrary, $method ),
+			'Class \SMW\Scribunto\ScribuntoLuaLibrary has method \'' . $method . '()\' missing!'
+		);
+	}
+
+	/**
+	 * Tests method getPropertyType
+	 *
+	 * @return void
+	 */
+	public function testGetPropertyType() {
+		$this->assertEmpty(
+			$this->scribuntoLuaLibrary->getPropertyType( '' )[0]
+		);
+		$this->assertEquals(
+			'_dat',
+			$this->scribuntoLuaLibrary->getPropertyType( 'Modification date' )[0]
+		);
+		$this->assertEquals(
+			'_wpg',
+			$this->scribuntoLuaLibrary->getPropertyType( 'Foo' )[0]
+		);
+	}
+
+	/**
+	 * Tests method getQueryResult
+	 *
+	 * @return void
+	 */
+	public function testGetQueryResult() {
+		$this->assertArrayHasKey(
+			'meta',
+			$this->scribuntoLuaLibrary->getQueryResult()[0]
+		);
+		$this->assertArrayHasKey(
+			'count',
+			$this->scribuntoLuaLibrary->getQueryResult()[0]['meta']
+		);
+		$this->assertEquals(
+			0,
+			$this->scribuntoLuaLibrary->getQueryResult()[0]['meta']['count']
+		);
+		$this->assertArrayHasKey(
+			'printrequests',
+			$this->scribuntoLuaLibrary->getQueryResult( '[[Modification date::+]]|?Modification date|limit=0|mainlabel=-' )[0]
+		);
+		$this->assertArrayHasKey(
+			0,
+			$this->scribuntoLuaLibrary->getQueryResult( '[[Modification date::+]]|?Modification date|limit=0|mainlabel=-' )[0]['printrequests']
+		);
+		$this->assertArrayHasKey(
+			'label',
+			$this->scribuntoLuaLibrary->getQueryResult( '[[Modification date::+]]|?Modification date|limit=0|mainlabel=-' )[0]['printrequests'][0]
+		);
+		$this->assertEquals(
+			'Modification date',
+			$this->scribuntoLuaLibrary->getQueryResult( '[[Modification date::+]]|?Modification date|limit=0|mainlabel=-' )[0]['printrequests'][0]['label']
+		);
+	}
+
+	/**
+	 * Tests method info
+	 *
+	 * @return void
+	 */
+	public function testInfo() {
+		$this->assertEmpty(
+			$this->scribuntoLuaLibrary->info( null )
+		);
+		$this->assertEmpty(
+			$this->scribuntoLuaLibrary->info( '' )
+		);
+		$this->assertInternalType(
+			'string',
+			$this->scribuntoLuaLibrary->info( 'Test info text' )[0]
+		);
+		$this->assertStringStartsWith(
+			'<span',
+			$this->scribuntoLuaLibrary->info( 'Test info text' )[0]
+		);
+		$this->assertStringEndsWith(
+			'</span>',
+			$this->scribuntoLuaLibrary->info( 'Test info text' )[0]
+		);
+		$this->assertEquals(
+			1,
+			preg_match('~^<span class=.*<span class="[^"]*info">.*>Test info text<.*</span>$~', $this->scribuntoLuaLibrary->info( 'Test info text' )[0])
+		);
+		$this->assertEquals(
+			1,
+			preg_match('~^<span class=.*<span class="[^"]*warning">.*>Test info text<.*</span>$~', $this->scribuntoLuaLibrary->info( 'Test info text', 'warning' )[0])
+		);
+		$this->assertEquals(
+			1,
+			preg_match('~^<span class=.*<span class="[^"]*info">.*>Test info text<.*</span>$~', $this->scribuntoLuaLibrary->info( 'Test info text', 'invalid' )[0])
+		);
+	}
+
+
+	/**
+	 * Tests method set through assertions based upon
+	 * dataProvider {@see \SMW\Scribunto\Tests\ScribuntoLuaLibraryTest::dataProviderSetTest}
+	 *
+	 * @dataProvider dataProviderSetTest
+	 * @param array $arguments arguments passed to function
+	 * @param mixed $expected expected return value
+	 */
+	public function testSet( $arguments, $expected) {
+		$this->assertEquals(
+			$expected,
+			$this->scribuntoLuaLibrary->set($arguments)
+		);
+	}
+
+	/**
+	 * Tests method subobject through assertions based upon
+	 * dataProvider {@see \SMW\Scribunto\Tests\ScribuntoLuaLibraryTest::dataProviderSubobjectTest}
+	 *
+	 * @dataProvider dataProviderSubobjectTest
+	 * @param array $arguments arguments passed to function
+	 * @param mixed $expected expected return value
+	 */
+	public function testSubobject( $arguments, $expected ) {
+		$this->assertEquals(
+			$expected,
+			call_user_func_array( array( $this->scribuntoLuaLibrary, 'subobject' ), $arguments )
+		);
+	}
+
+	/**
+	 * Data provider for {@see testFunctions}
+	 *
+	 * @see testFunctions
+	 *
+	 * @return array
+	 */
+	public function dataProviderFunctionTest() {
+
+		return [
+			[ 'getPropertyType' ],
+			[ 'getQueryResult' ],
+			[ 'info' ],
+			[ 'set' ],
+			[ 'subobject' ]
+		];
+	}
+
+	/**
+	 * Data provider for {@see testSet}
+	 *
+	 * @see testSet
+	 *
+	 * @return array
+	 */
+	public function dataProviderSetTest() {
+		$provider = array(
+			[
+				[],
+				null
+			],
+			[
+				[ 'has type=page' ],
+				[ 1 => true ]
+			],
+			[
+				[ 'has type=test' ],
+				[ array( 1 => false, 'error' => wfMessage('smw_unknowntype')->inLanguage('en')->plain() ) ]
+			],
+			[
+				[ '1215623e790d918773db943232068a93b21c9f1419cb85666c6558e87f5b7d47=test' ],
+				[ 1 => true ]
+			]
+		);
+
+		return $provider;
+	}
+
+	/**
+	 * Data provider for {@see testSubobject}
+	 *
+	 * @see testSubobject
+	 *
+	 * @return array
+	 */
+	public function dataProviderSubobjectTest()
+	{
+		$provider = array(
+			[
+				[ [] ],
+				null
+			],
+			[
+				[ null ],
+				null
+			],
+			[
+				[ '' ],
+				null
+			],
+			[
+				[ [ 'has type=page', 'Allows value=test' ] ],
+				[ 1 => true ]
+			],
+			[
+				[ [ 'has type=test', 'Allows value=test' ] ],
+				[ array( 1 => false, 'error' => wfMessage('smw_unknowntype')->inLanguage('en')->plain() ) ]
+			],
+			[
+				[ [ 'has type=page', 'Allows value=test','1215623e790d918773db943232068a93b21c9f1419cb85666c6558e87f5b7d47=test' ] ],
+				[ 1 => true ]
+			],
+			[
+				[ [], '01234567890_testStringAsId' ],
+				null
+			],
+			[
+				[ null, '01234567890_testStringAsId' ],
+				null
+			],
+			[
+				[ '', '01234567890_testStringAsId' ],
+				null
+			],
+			[
+				[ [ 'has type=page', 'Allows value=test' ], '01234567890_testStringAsId' ],
+				[ 1 => true ]
+			],
+			[
+				[ [ 'has type=test', 'Allows value=test' ], '01234567890_testStringAsId' ],
+				[ array( 1 => false, 'error' => wfMessage('smw_unknowntype')->inLanguage('en')->plain() ) ]
+			],
+			[
+				[ [ 'has type=page', 'Allows value=test','1215623e790d918773db943232068a93b21c9f1419cb85666c6558e87f5b7d47=test' ], '01234567890_testStringAsId' ],
+				[ 1 => true ]
+			],
+		);
+
+		return $provider;
+	}
+}

--- a/tests/phpunit/Unit/mw.smw.tests.lua
+++ b/tests/phpunit/Unit/mw.smw.tests.lua
@@ -1,0 +1,97 @@
+--[[
+	Tests for smw.info module
+
+	@since 1.0
+
+	@licence GNU GPL v2+
+	@author oetterer
+]]
+
+local testframework = require 'Module:TestFramework'
+
+-- Tests
+local tests = {
+	{
+		name = 'check package load',
+		func = function ( args )
+			return package.loaded['mw.smw'] == mw.smw
+			end,
+		args = {},
+		expect = { true }
+	},
+	{
+		name = 'check bindings',
+		func = function ( args )
+				return type( mw.smw )
+			end,
+		args = {},
+		expect = { 'table' }
+	},
+	{
+		name = 'getPropertyType function registered and callable',
+		func = function ( args )
+			local result, returnVal =  pcall( mw.smw[args], '' )
+			if result then
+				return type( mw.smw[args] ), result
+			else
+				return type( mw.smw[args] ), result, returnVal
+			end
+		end,
+		args = { 'getPropertyType' },
+		expect = { 'function', true }
+	},
+	{
+		name = 'getQueryResult function registered and callable',
+		func = function ( args )
+			local result, returnVal =  pcall( mw.smw[args], '' )
+			if result then
+				return type( mw.smw[args] ), result
+			else
+				return type( mw.smw[args] ), result, returnVal
+			end
+		end,
+		args = { 'getQueryResult' },
+		expect = { 'function', true }
+	},
+	{
+		name = 'info function registered and callable',
+		func = function ( args )
+			local result, returnVal =  pcall( mw.smw[args], '' )
+			if result then
+				return type( mw.smw[args] ), result
+			else
+				return type( mw.smw[args] ), result, returnVal
+			end
+		end,
+		args = { 'info' },
+		expect = { 'function', true }
+	},
+	{
+		name = 'set function registered and callable',
+		func = function ( args )
+			local result, returnVal =  pcall( mw.smw[args], '' )
+			if result then
+				return type( mw.smw[args] ), result
+			else
+				return type( mw.smw[args] ), result, returnVal
+			end
+		end,
+		args = { 'set' },
+		expect = { 'function', true }
+	},
+	{
+		name = 'subobject function registered and callable',
+		func = function ( args )
+			local result, returnVal =  pcall( mw.smw[args], '' )
+			if result then
+				return type( mw.smw[args] ), result
+			else
+				return type( mw.smw[args] ), result, returnVal
+			end
+		end,
+		args = { 'subobject' },
+		expect = { 'function', true }
+	},
+}
+
+return testframework.getTestProvider( tests )


### PR DESCRIPTION
… for the methods whithin ScribuntoLuaLibrary

also augments docs/functions.md

This addresses issues from PR #20 . Notably

- unittests outside lua where added to test the public methods of ScribuntoLuaLibrary directly in php rather than through lua
- subobject was re-added since the last PR ( #19 ) had merge conflicts
- the documentation was augmented to provide guidance for all available functions. also some usage examples where added
- a new lua test suite was added to test the correct binding of php functions to lua functions

Note: with this most of the lua test suites will probably become obsolete since all the tests are done in php as well.