### PR TITLE
Add integration test infrastructure, refs #27

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,11 @@ have a look at the contribution guideline.
 ## Tests
 
 This extension provides unit and integration tests that are run by a [continues integration platform][travis]
-but can also be executed using `composer phpunit` from the extension base directory.
+but can also be executed using the `composer phpunit` command from the extension base directory that will
+run all tests. In order to run only a specific test suit, the following commands are provided for convenience:
+
+- `composer unit` to run all unit tests
+- `composer integration` to run all integration tests (which requires an active MediaWiki, DB connection)
 
 ## License
 

--- a/SemanticScribunto.php
+++ b/SemanticScribunto.php
@@ -82,7 +82,7 @@ class SemanticScribunto {
 	/**
 	 * @since 1.0
 	 */
-	public static function checkRequirements() {
+	public static function doCheckRequirements() {
 
 		if ( version_compare( $GLOBALS[ 'wgVersion' ], '1.26', 'lt' ) ) {
 			die( '<b>Error:</b> <a href="https://github.com/SemanticMediaWiki/SemanticScribunto/">Semantic Scribunto</a> is only compatible with MediaWiki 1.26 or above. You need to upgrade MediaWiki first.' );
@@ -104,7 +104,7 @@ class SemanticScribunto {
 	public static function onExtensionFunction() {
 
 		// Check requirements after LocalSetting.php has been processed
-		self::checkRequirements();
+		self::doCheckRequirements();
 
 		$hookRegistry = new HookRegistry();
 		$hookRegistry->register();
@@ -113,10 +113,25 @@ class SemanticScribunto {
 	/**
 	 * @since 1.0
 	 *
+	 * @param string|null $dependency
+	 *
 	 * @return string|null
 	 */
-	public static function getVersion() {
-		return SMW_SCRIBUNTO_VERSION;
+	public static function getVersion( $dependency = null ) {
+
+		if ( $dependency === null && defined( 'SMW_SCRIBUNTO_VERSION' ) ) {
+			return SMW_SCRIBUNTO_VERSION;
+		}
+
+		if ( $dependency === 'SMW' && defined( 'SMW_VERSION' ) ) {
+			return SMW_VERSION;
+		}
+
+		if ( $dependency === 'Lua' && method_exists( 'Scribunto_LuaStandaloneInterpreter', 'getLuaVersion' ) ) {
+			return Scribunto_LuaStandaloneInterpreter::getLuaVersion( array( 'luaPath' => null ) );
+		}
+
+		return null;
 	}
 
 }

--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,8 @@
 	},
 	"scripts":{
 		"phpunit": "php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist",
+		"unit": "composer phpunit -- --testsuite semantic-scribunto-unit",
+		"integration": "composer phpunit -- --testsuite semantic-scribunto-integration",
 		"cs": [
 			"vendor/bin/phpcs src/* tests/* --standard=phpcs.xml --extensions=php -sp",
 			"vendor/bin/phpmd src/,tests/ text phpmd.xml"

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -29,6 +29,15 @@ class HookRegistry {
 	/**
 	 * @since  1.0
 	 */
+	public function clear() {
+		foreach ( $this->handlers as $name => $callback ) {
+			Hooks::clear( $name );
+		}
+	}
+
+	/**
+	 * @since  1.0
+	 */
 	public function register() {
 		foreach ( $this->handlers as $name => $callback ) {
 			Hooks::register( $name, $callback );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,14 +9,17 @@ date_default_timezone_set( 'UTC' );
 ini_set( 'display_errors', 1 );
 
 if ( !is_readable( $autoloaderClassPath = __DIR__ . '/../../SemanticMediaWiki/tests/autoloader.php' ) ) {
-	die( 'The Semantic MediaWiki test autoloader is not available' );
+	die( "\nThe Semantic MediaWiki test autoloader is not available" );
 }
 
-if ( ( $version = SemanticScribunto::getVersion() ) === null ) {
-	die( "\Semantic Scribunto is not available, please check your Composer or LocalSettings.\n" );
+if ( !class_exists( 'SemanticScribunto' ) || ( $version = SemanticScribunto::getVersion() ) === null ) {
+	die( "\nSemantic Scribunto is not available or loaded, please check your Composer or LocalSettings.\n" );
 }
 
 print sprintf( "\n%-20s%s\n", "Semantic Scribunto: ", $version );
+print sprintf( "%-20s%s\n", "Lua version: ", SemanticScribunto::getVersion( 'Lua' ) );
+
+// What is the Scribunto version?? Who knows ..., it doesn't have a version number
 
 $autoLoader = require $autoloaderClassPath;
 $autoLoader->addPsr4( 'SMW\\Scribunto\\Tests\\', __DIR__ . '/phpunit/Unit' );

--- a/tests/phpunit/Integration/JSONScript/Fixtures/module.smw.lua
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/module.smw.lua
@@ -1,0 +1,71 @@
+-- Module:SMW
+local p = {}
+
+-- Return results
+function p.ask(frame)
+
+    if not mw.smw then
+        return "mw.smw module not found"
+    end
+
+    if frame.args[1] == nil then
+        return "no parameter found"
+    end
+
+    local queryResult = mw.smw.ask( frame.args )
+
+    if queryResult == nil then
+        return "(no values)"
+    end
+
+    if type( queryResult ) == "table" then
+        local myResult = ""
+        for num, row in pairs( queryResult ) do
+            myResult = myResult .. '* This is result #' .. num .. '\n'
+            for k, v in pairs( row ) do
+                myResult = myResult .. '** ' .. k .. ': ' .. v .. '\n'
+            end
+        end
+        return myResult
+    end
+
+    return queryResult
+end
+
+-- another example, ask used inside another function
+function p.inlineAsk()
+
+    local entityAttributes = {
+        'has name=name',
+        'has age=age',
+        'has color=color'
+    }
+    local category = 'thingies'
+
+    -- build query
+    local query = {}
+    table.insert(query, '[[Category:' .. category .. ']]')
+
+    for _, v in pairs( entityAttributes ) do
+        table.insert( query, '?' .. v )
+    end
+
+    query.mainlabel = 'origin'
+    query.limit = 10
+
+    local result = mw.smw.ask( query )
+
+    local output = ''
+    if result and #result then
+
+        for num, entityData in pairs( result ) do
+            -- further process your data
+            output = output .. entityData.origin .. ' (' .. num .. ') has name ' .. entityData.name
+                .. ', color ' .. entityData.color .. ', and age ' .. entityData.age
+        end
+    end
+
+    return output
+end
+
+return p

--- a/tests/phpunit/Integration/JSONScript/README.md
+++ b/tests/phpunit/Integration/JSONScript/README.md
@@ -1,0 +1,19 @@
+## Integration tests
+
+- `ask-001.json` Test `mw.smw.ask` using functions defined in module.smw.lua
+
+### Assertions
+
+Integration tests aim to prove that the "integration" between MediaWiki,
+Semantic MediaWiki, and Scribunto works at a sufficient level therefore assertion
+may only check or verify a specific part of an output or data to avoid that
+system information (DB ID, article url etc.) distort to overall test results.
+
+### Add a new test case
+
+- Follow the `ask-001.json` example on how to structure the JSON file (setup,
+  test etc.)
+- Add example pages with content (including value annotations `[[SomeProperty::SomeValue]]`)
+  expected to be tested
+- If necessary add a new lua module file to the Fixtures directory and import the
+  content for the test (see `ask-001.json`)

--- a/tests/phpunit/Integration/JSONScript/SemanticScribuntoJsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/SemanticScribuntoJsonTestCaseScriptRunnerTest.php
@@ -1,0 +1,231 @@
+<?php
+
+namespace SMW\Scribunto\Integration\JSONScript;
+
+use SMW\Scribunto\HookRegistry;
+use SMW\Tests\JsonTestCaseScriptRunner;
+use SMW\Tests\JsonTestCaseFileHandler;
+use SMW\DIWikiPage;
+
+/**
+ * @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests#write-integration-tests-using-json-script
+ *
+ * `JsonTestCaseScriptRunner` provisioned by SMW is a base class allowing to use a JSON
+ * format to create test definitions with the objective to compose "real" content
+ * and test integration with MediaWiki, Semantic MediaWiki, and Scribunto.
+ *
+ * The focus is on describing test definitions with its content and specify assertions
+ * to control the expected base line.
+ *
+ * `JsonTestCaseScriptRunner` will handle the tearDown process and ensures that no test
+ * data are leaked into a production system but requires an active DB connection.
+ *
+ * @group semantic-scribunto
+ * @group medium
+ *
+ * @license GNU GPL v2+
+ * @since 1.0
+ *
+ * @author mwjames
+ */
+class SemanticScribuntoJsonTestCaseScriptRunnerTest extends JsonTestCaseScriptRunner {
+
+	private $semanticDataValidator;
+	private $stringValidator;
+	private $hookRegistry;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$validatorFactory = $this->testEnvironment->getUtilityFactory()->newValidatorFactory();
+
+		$this->semanticDataValidator = $validatorFactory->newSemanticDataValidator();
+		$this->stringValidator = $validatorFactory->newStringValidator();
+
+		$this->hookRegistry = new HookRegistry();
+
+		$this->hookRegistry->clear();
+		$this->hookRegistry->register();
+	}
+
+	/**
+	 * @see JsonTestCaseScriptRunner::getRequiredJsonTestCaseMinVersion
+	 */
+	protected function getRequiredJsonTestCaseMinVersion() {
+		return '1';
+	}
+
+	/**
+	 * @see JsonTestCaseScriptRunner::getTestCaseLocation
+	 */
+	protected function getTestCaseLocation() {
+		return __DIR__ . '/TestCases';
+	}
+
+	/**
+	 * Returns a list of files, an empty list is a sign to run all registered
+	 * tests.
+	 *
+	 * @see JsonTestCaseScriptRunner::getListOfAllowedTestCaseFiles
+	 */
+	protected function getAllowedTestCaseFiles() {
+		return array();
+	}
+
+	/**
+	 * @see JsonTestCaseScriptRunner::runTestCaseFile
+	 *
+	 * @param JsonTestCaseFileHandler $jsonTestCaseFileHandler
+	 */
+	protected function runTestCaseFile( JsonTestCaseFileHandler $jsonTestCaseFileHandler ) {
+
+		$this->checkEnvironmentToSkipCurrentTest( $jsonTestCaseFileHandler );
+
+		// Defines settings that can be altered during a test run with each test
+		// having the possibility to change those value, settings will be reset to
+		// original value after the test has finished.
+		$permittedSettings = array(
+			'smwgNamespacesWithSemanticLinks',
+			'smwgPageSpecialProperties',
+			'wgLanguageCode',
+			'wgContLang',
+			'wgLang'
+		);
+
+		foreach ( $permittedSettings as $key ) {
+			$this->changeGlobalSettingTo(
+				$key,
+				$jsonTestCaseFileHandler->getSettingsFor( $key )
+			);
+		}
+
+		// Pages defined in the JSON setup: { ... } are processed and created
+		// before the actual assertion
+		$this->createPagesFor(
+			$jsonTestCaseFileHandler->getPageCreationSetupList(),
+			NS_MAIN
+		);
+
+		foreach ( $jsonTestCaseFileHandler->findTestCasesByType( 'parser' ) as $case ) {
+
+			if ( !isset( $case['subject'] ) ) {
+				break;
+			}
+
+			// Assert function are defined individually by each TestCaseRunner
+			// to ensure a wide range of scenarios can be supported.
+			$this->assertSemanticDataForCase( $case, $jsonTestCaseFileHandler->getDebugMode() );
+			$this->assertParserOutputForCase( $case );
+		}
+	}
+
+	/**
+	 * Assert the SemanticData object available after a entity/page has been
+	 * stored.
+	 *
+	 * ```
+	 * "assert-store": {
+	 * 	"semantic-data": {
+	 * 		"strictPropertyValueMatch": false,
+	 * 		"propertyCount": 4,
+	 * 		"propertyKeys": [
+	 * 			"Testproperty1",
+	 * 			"Testproperty2",
+	 * 			"_SKEY",
+	 * 			"_MDAT"
+	 * 		],
+	 * 		"propertyValues": [
+	 * 			"200"
+	 * 		]
+	 * 	}
+	 * }
+	 * ```
+	 */
+	private function assertSemanticDataForCase( $case, $debugMode ) {
+
+		// Allows for data to be re-read from the DB instead of being fetched
+		// from the store-id-cache
+		if ( isset( $case['store']['clear-cache'] ) && $case['store']['clear-cache'] ) {
+			$this->store->clear();
+		}
+
+		if ( !isset( $case['assert-store'] ) || !isset( $case['assert-store']['semantic-data'] ) ) {
+			return;
+		}
+
+		$subject = DIWikiPage::newFromText(
+			$case['subject'],
+			isset( $case['namespace'] ) ? constant( $case['namespace'] ) : NS_MAIN
+		);
+
+		$semanticData = $this->store->getSemanticData( $subject );
+
+		if ( $debugMode ) {
+			print_r( $semanticData );
+		}
+
+		if ( isset( $case['errors'] ) && $case['errors'] !== array() ) {
+			$this->assertNotEmpty(
+				$semanticData->getErrors()
+			);
+		}
+
+		$this->semanticDataValidator->assertThatPropertiesAreSet(
+			$case['assert-store']['semantic-data'],
+			$semanticData,
+			$case['about']
+		);
+
+		$this->assertInProperties(
+			$subject,
+			$case['assert-store']['semantic-data'],
+			$case['about']
+		);
+	}
+
+	/**
+	 * Assert the text content which is available after the parse in the
+	 * ParserOutput object.
+	 *
+	 * ```
+	 * "assert-output": {
+	 * 	"to-contain": [
+	 * 		"Foo"
+	 * 	],
+	 * 	"not-contain": [
+	 * 		"Bar"
+	 * 	]
+	 * }
+	 * ```
+	 */
+	private function assertParserOutputForCase( $case ) {
+
+		if ( !isset( $case['assert-output'] ) ) {
+			return;
+		}
+
+		$subject = DIWikiPage::newFromText(
+			$case['subject'],
+			isset( $case['namespace'] ) ? constant( $case['namespace'] ) : NS_MAIN
+		);
+
+		$parserOutput = $this->testEnvironment->getUtilityFactory()->newPageReader()->getEditInfo( $subject->getTitle() )->output;
+
+		if ( isset( $case['assert-output']['to-contain'] ) ) {
+			$this->stringValidator->assertThatStringContains(
+				$case['assert-output']['to-contain'],
+				$parserOutput->getText(),
+				$case['about']
+			);
+		}
+
+		if ( isset( $case['assert-output']['not-contain'] ) ) {
+			$this->stringValidator->assertThatStringNotContains(
+				$case['assert-output']['not-contain'],
+				$parserOutput->getText(),
+				$case['about']
+			);
+		}
+	}
+
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/ask-001.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/ask-001.json
@@ -1,0 +1,75 @@
+{
+	"description": "Test `mw.smw.ask` functions defined in module.smw.lua",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has text",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has number",
+			"contents": "[[Has type::Number]]"
+		},
+		{
+			"namespace": "NS_MODULE",
+			"page": "smw",
+			"contents": {
+				"import-from": "/../Fixtures/module.smw.lua"
+			}
+		},
+		{
+			"page": "Scribunto/001/1",
+			"contents": "[[Has text::Is a Scribunto example text]] [[Category:ask-001]]"
+		},
+		{
+			"page": "Scribunto/001/Q.1",
+			"contents": "{{#invoke:smw|ask|[[Category:ask-001]] [[Has text::+]]|?#-=page|?Has text |limit=3 |mainlabel=-}}"
+		},
+		{
+			"page": "Scribunto/001/2",
+			"contents": "[[Has number::42]] [[Category:ask-001]]"
+		},
+		{
+			"page": "Scribunto/001/Q.2",
+			"contents": "{{#invoke:smw|ask|[[Category:ask-001]] [[Has number::+]]|?#-=page|?Has number |limit=3 }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 verify output for the `[[Category:ask-001]] [[Has text::+]]` query",
+			"subject": "Scribunto/001/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"<ul><li> page: Scribunto/001/1</li>",
+					"<li> Has text: Is a Scribunto example text</li></ul></li></ul>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 verify output for the `[[Category:ask-001]] [[Has number::+]]` query",
+			"subject": "Scribunto/001/Q.2",
+			"assert-output": {
+				"to-contain": [
+					"title=\"Scribunto/001/2\">Scribunto/001/2</a></li>",
+					"<li> page: Scribunto/001/2</li>",
+					"<li> Has number: 42</li></ul></li></ul>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		]
+	},
+	"meta": {
+		"version": "1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
- `SemanticScribuntoJsonTestCaseScriptRunnerTest` extends `JsonTestCaseScriptRunner`
- Requires https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2084 making it possible that `CONTENT_MODEL_SCRIBUNTO` pages can be created when importing lua scripts

 refs #27