### PR TITLE
ScribuntoLuaLibrary now correctly converts any given array into a lua table (recursively)

### DIFF
--- a/src/LuaAskResultProcessor.php
+++ b/src/LuaAskResultProcessor.php
@@ -193,8 +193,9 @@ class LuaAskResultProcessor {
 			// there was only one semantic value found. reduce the array to this value
 			$resultArrayData = array_shift( $resultArrayData );
 		} else {
-			// $key has multiple values. keep the array, but un-shift it (remember: lua array counting starts with 1)
-			array_unshift( $resultArrayData, null );
+			// $key has multiple values. keep the array
+			// Note: we do not un-shift it (remember: lua array counting starts with 1), but the defer to
+			// conversion to a lua table to a later step
 		}
 
 		return $resultArrayData;

--- a/src/ScribuntoLuaLibrary.php
+++ b/src/ScribuntoLuaLibrary.php
@@ -72,11 +72,7 @@ class ScribuntoLuaLibrary extends Scribunto_LuaLibraryBase {
 
 		$result = $luaResultProcessor->getQueryResultAsTable();
 
-		if ( !empty( $result ) ) {
-			array_unshift( $result, null );
-		}
-
-		return array( $result );
+		return array( $this->convertArrayToLuaTable( $result ) );
 	}
 
 	/**
@@ -128,10 +124,12 @@ class ScribuntoLuaLibrary extends Scribunto_LuaLibraryBase {
 		$result = $queryResult->toArray();
 
 		if( !empty( $result["results"] ) ) {
-		    $result["results"] = array_combine( range( 1, count( $result["results"] ) ), array_values( $result["results"] ) );
+			// as of now, "results" has page names as keys. lua is not very good, keeping non-number keys in order
+			// so replace string keys with the corresponding number, starting with 0.
+		    $result["results"] = array_combine( range( 0, count( $result["results"] ) - 1 ), array_values( $result["results"] ) );
 		}
 
-		return array( $result );
+		return array( $this->convertArrayToLuaTable( $result ) );
 	}
 
 	/**
@@ -252,6 +250,25 @@ class ScribuntoLuaLibrary extends Scribunto_LuaLibraryBase {
 
 		// on success, return true
 		return array( 1 => true );
+	}
+
+	/**
+	 * This takes an array and converts it so, that the result is a viable lua table.
+	 * I.e. the resulting table has its numerical indices start with 1
+	 * If `$ar` is not an array, it is simply returned
+	 * @param mixed $ar
+	 * @return mixed array
+	 */
+	private function convertArrayToLuaTable( $ar ) {
+
+		if ( is_array( $ar) ) {
+			foreach ( $ar as $key => $value ) {
+				$ar[$key] = $this->convertArrayToLuaTable( $value );
+			}
+			array_unshift( $ar, '' );
+			unset( $ar[0] );
+		}
+		return $ar;
 	}
 
 	/**

--- a/tests/phpunit/Integration/JSONScript/Fixtures/module.smw.getQueryResult.lua
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/module.smw.getQueryResult.lua
@@ -55,13 +55,13 @@ function convertResultTableToString( queryResult )
 
     local queryResult = queryResult
 
-    if queryResult == nil then
+    if queryResult == nil or #queryResult == 0 then
         return "(no values)"
     end
 
     if type( queryResult ) == "table" then
         local myResult = ""
-        for num, row in pairs( queryResult ) do
+        for num, row in ipairs( queryResult ) do
             myResult = myResult .. '* This is result #' .. num .. '\n'
             for property, data in pairs( row ) do
                 local dataOutput = data
@@ -79,17 +79,17 @@ end
 
 function filterForMainLabelOnly( queryResult, keepPrintouts )
 
-    local queryResult = queryResult
+    local qr = queryResult
     if queryResult.results then
-        queryResult = queryResult.results
+        qr = queryResult.results
     end
 
-    if type( queryResult ) ~= 'table' then
-        return queryResult
+    if type( qr ) ~= 'table' then
+        return qr
     end
 
     local filteredResult = {}
-    for num, row in pairs( queryResult ) do
+    for num, row in pairs( qr ) do
         if type( row ) == 'table' then
             local printOuts = row.printouts
             for field, _ in pairs( row ) do
@@ -163,7 +163,7 @@ function varDump( entity, indent )
         local output = '(table)[' .. #entity .. ']:'
         indent = indent .. '  '
         for k, v in pairs( entity ) do
-            output = output .. '\n' .. indent .. k .. ': ' .. varDump( v, indent )
+			output = output .. '\n' .. indent .. '(' .. type(k) .. ') ' .. k .. ': ' .. varDump( v, indent )
         end
         return output
     elseif type( entity ) == 'function' then

--- a/tests/phpunit/Unit/LuaAskResultProcessorTest.php
+++ b/tests/phpunit/Unit/LuaAskResultProcessorTest.php
@@ -301,7 +301,7 @@ class LuaAskResultProcessorTest extends \PHPUnit_Framework_TestCase {
 		return [
 			[ null, [] ],
 			[ 42, [ 42 ] ],
-			[ [ null, 'foo', 'bar' ], [ 'foo', 'bar' ] ]
+			[ [ 'foo', 'bar' ], [ 'foo', 'bar' ] ]
 		];
 	}
 

--- a/tests/phpunit/Unit/ScribuntoLuaLibraryResultsTest.php
+++ b/tests/phpunit/Unit/ScribuntoLuaLibraryResultsTest.php
@@ -51,20 +51,20 @@ class ScribuntoLuaLibraryResultsTest extends ScribuntoLuaEngineTestBase {
 			$this->getScribuntoLuaLibrary()->getQueryResult( '[[Modification date::+]]|?Modification date|limit=0|mainlabel=-' )[0]
 		);
 		$this->assertArrayHasKey(
-			0,
+			1,
 			$this->getScribuntoLuaLibrary()->getQueryResult( '[[Modification date::+]]|?Modification date|limit=0|mainlabel=-' )[0]['printrequests']
 		);
 		$this->assertArrayHasKey(
 			'label',
-			$this->getScribuntoLuaLibrary()->getQueryResult( '[[Modification date::+]]|?Modification date|limit=0|mainlabel=-' )[0]['printrequests'][0]
+			$this->getScribuntoLuaLibrary()->getQueryResult( '[[Modification date::+]]|?Modification date|limit=0|mainlabel=-' )[0]['printrequests'][1]
 		);
 		$this->assertEquals(
 			'Modification date',
-			$this->getScribuntoLuaLibrary()->getQueryResult( '[[Modification date::+]]|?Modification date|limit=0|mainlabel=-' )[0]['printrequests'][0]['label']
+			$this->getScribuntoLuaLibrary()->getQueryResult( '[[Modification date::+]]|?Modification date|limit=0|mainlabel=-' )[0]['printrequests'][1]['label']
 		);
 		$this->assertEquals(
 			'Modification date',
-			$this->getScribuntoLuaLibrary()->getQueryResult( [ '[[Modification date::+]]', '?Modification date', 'limit' => 0, 'mainlabel=-' ] )[0]['printrequests'][0]['label']
+			$this->getScribuntoLuaLibrary()->getQueryResult( [ '[[Modification date::+]]', '?Modification date', 'limit' => 0, 'mainlabel=-' ] )[0]['printrequests'][1]['label']
 		);
 	}
 }


### PR DESCRIPTION
The problem was, that getQueryResult's result contained 0-indexed arrays. Now ScribuntoLuaLibrary has a private method that convertes an array in a lua compatible table. It works recursively, so that should fix that issue.

I also adapted the LuaAskResultProcessor to generate normal arrays and then utilize that new function. I found this more straight forward.