### PR TITLE
fixes #i39 (tests not up to date with changes in smw )

### DIFF
--- a/src/LibraryFactory.php
+++ b/src/LibraryFactory.php
@@ -109,7 +109,7 @@ class LibraryFactory {
 	 *
 	 * @param Parser $parser
 	 *
-	 * @return \SMW\ParserFunctions\SubobjectParserFunction
+	 * @return \SMW\SubobjectParserFunction
 	 */
 	public function newSubobjectParserFunction( Parser $parser ) {
 		return ApplicationFactory::getInstance()->newParserFunctionFactory( $parser )->newSubobjectParserFunction( $parser );

--- a/tests/phpunit/Integration/JSONScript/Fixtures/module.smw.lua
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/module.smw.lua
@@ -117,10 +117,14 @@ function convertResultTableToString( queryResult )
         local myResult = ""
         for num, row in ipairs( queryResult ) do
             myResult = myResult .. '* This is result #' .. num .. '\n'
+--			myResult = myResult .. '** elements are:' .. table.concat ( getKeys( row ), ',' )  .. '\n'
+--			myResult = myResult .. '** num elements:' .. getNum( row )  .. '\n'
             for property, data in pairs( row ) do
                 local dataOutput = data
                 if type( data ) == 'table' then
                     dataOutput = mw.text.listToText( data, ', ', ' and ')
+				elseif type( data ) == 'boolean' then
+					dataOutput = data and 'true' or 'false'
                 end
                 myResult = myResult .. '** ' .. property .. ': ' .. dataOutput .. '\n'
             end
@@ -129,6 +133,19 @@ function convertResultTableToString( queryResult )
     end
 
     return queryResult
+end
+
+function getNum( t )
+	local keys = getKeys( t );
+	return #keys
+end
+
+function getKeys( t )
+	local keys = {}
+	for k, v in pairs( t ) do
+		table.insert( keys, k )
+	end
+	return keys
 end
 
 function varDump( entity, indent )

--- a/tests/phpunit/Integration/JSONScript/TestCases/ask-001.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/ask-001.json
@@ -12,6 +12,21 @@
 			"contents": "[[Has type::Number]]"
 		},
 		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has boolean",
+			"contents": "[[Has type::Boolean]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has date",
+			"contents": "[[Has type::Date]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has url",
+			"contents": "[[Has type::Url]]"
+		},
+		{
 			"namespace": "NS_MODULE",
 			"page": "smw",
 			"contents": {
@@ -19,12 +34,24 @@
 			}
 		},
 		{
-			"page": "Scribunto/ask/001/1",
+			"page": "Scribunto/ask/001/0",
 			"contents": "[[Has text::Is a Scribunto example text]] [[Category:ask-001]]"
 		},
 		{
-			"page": "Scribunto/ask/001/2",
+			"page": "Scribunto/ask/001/1",
 			"contents": "[[Has number::42]] [[Category:ask-001]]"
+		},
+		{
+			"page": "Scribunto/ask/001/2",
+			"contents": "[[Has boolean::true]] [[Category:ask-001]]"
+		},
+		{
+			"page": "Scribunto/ask/001/3",
+			"contents": "[[Has date::2017-12-24]] [[Category:ask-001]]"
+		},
+		{
+			"page": "Scribunto/ask/001/4",
+			"contents": "[[Has url::https://www.semantic-mediawiki.org/]] [[Category:ask-001]]"
 		},
 		{
 			"page": "Scribunto/ask/001/Q.0",
@@ -33,6 +60,18 @@
 		{
 			"page": "Scribunto/ask/001/Q.1",
 			"contents": "{{#invoke:smw|ask|[[Category:ask-001]] [[Has number::+]]|?#-=page|?Has number |limit=3 }}"
+		},
+		{
+			"page": "Scribunto/ask/001/Q.2",
+			"contents": "{{#invoke:smw|ask|[[Category:ask-001]] [[Has boolean::+]]|?#-=page|?Has boolean |limit=3 |mainlabel=-}}"
+		},
+		{
+			"page": "Scribunto/ask/001/Q.3",
+			"contents": "{{#invoke:smw|ask|[[Category:ask-001]] [[Has date::+]]|?#-=page|?Has date#-F[d.m.Y] |limit=3 |mainlabel=-}}"
+		},
+		{
+			"page": "Scribunto/ask/001/Q.4",
+			"contents": "{{#invoke:smw|ask|[[Category:ask-001]] [[Has url::+]]|?#-=page|?Has url |limit=3 |mainlabel=-}}"
 		}
 	],
 	"tests": [
@@ -42,8 +81,8 @@
 			"subject": "Scribunto/ask/001/Q.0",
 			"assert-output": {
 				"to-contain": [
-					"<ul><li> page: Scribunto/ask/001/1</li>",
-					"<li> Has text: Is a Scribunto example text</li></ul></li></ul>"
+					"<li> page: Scribunto/ask/001/0</li>",
+					"<li> Has text: Is a Scribunto example text</li>"
 				]
 			}
 		},
@@ -53,9 +92,42 @@
 			"subject": "Scribunto/ask/001/Q.1",
 			"assert-output": {
 				"to-contain": [
-					"title=\"Scribunto/ask/001/2\">Scribunto/ask/001/2</a></li>",
+					"title=\"Scribunto/ask/001/1\">Scribunto/ask/001/1</a></li>",
+					"<li> page: Scribunto/ask/001/1</li>",
+					"<li> Has number: 42</li>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2 verify output for the `[[Category:ask-001]] [[Has boolean::+]]` query",
+			"subject": "Scribunto/ask/001/Q.2",
+			"assert-output": {
+				"to-contain": [
 					"<li> page: Scribunto/ask/001/2</li>",
-					"<li> Has number: 42</li></ul></li></ul>"
+					"<li> Has boolean: true</li>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#3 verify output for the `[[Category:ask-001]] [[Has date::+]]` query",
+			"subject": "Scribunto/ask/001/Q.3",
+			"assert-output": {
+				"to-contain": [
+					"<li> page: Scribunto/ask/001/3</li>",
+					"<li> Has date: 24.12.2017</li>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#4 verify output for the `[[Category:ask-001]] [[Has url::+]]` query",
+			"subject": "Scribunto/ask/001/Q.4",
+			"assert-output": {
+				"to-contain": [
+					"<li> page: Scribunto/ask/001/4</li>",
+					"<li> Has url: <a rel=\"nofollow\" class=\"external free\" href=\"https://www.semantic-mediawiki.org/\">https://www.semantic-mediawiki.org/</a></li>"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/info-001.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/info-001.json
@@ -31,7 +31,7 @@
 			"subject": "Info-warning",
 			"assert-output": {
 				"to-contain": [
-					"<span class=\"smw-highlighter\" data-type=\"4\" data-state=\"inline\" data-title=\"Error\" title=\"an error text\">",
+					"<span class=\"smw-highlighter\" data-type=\"4\" data-state=\"inline\" data-title=\"Warning\" title=\"an error text\">",
 					"<span class=\"smwtticon warning\">",
 					"<div class=\"smwttcontent\">an error text</div>"
 				]
@@ -43,7 +43,7 @@
 			"subject": "Info-note",
 			"assert-output": {
 				"to-contain": [
-					"<span class=\"smw-highlighter\" data-type=\"7\" data-state=\"inline\" data-title=\"Note\" title=\"a note\">",
+					"<span class=\"smw-highlighter\" data-type=\"8\" data-state=\"inline\" data-title=\"Note\" title=\"a note\">",
 					"<span class=\"smwtticon note\">",
 					"<div class=\"smwttcontent\">a note</div>"
 				]
@@ -55,7 +55,7 @@
 			"subject": "Info-info",
 			"assert-output": {
 				"to-contain": [
-					"<span class=\"smw-highlighter\" data-type=\"5\" data-state=\"persistent\" data-title=\"Information\" title=\"an info text\">",
+					"<span class=\"smw-highlighter\" data-type=\"6\" data-state=\"persistent\" data-title=\"Information\" title=\"an info text\">",
 					"<span class=\"smwtticon info\">",
 					"<div class=\"smwttcontent\">an info text</div>"
 				]

--- a/tests/phpunit/Integration/JSONScript/TestCases/subobject-001.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/subobject-001.json
@@ -69,14 +69,14 @@
 			},
 			"assert-output": {
 				"to-contain": [
-					"Scribunto/subobject/001/0#_86e73ba4007c05bcb66e9a6824567241"
+					"Scribunto/subobject/001/0#_632434fc58dfec64d856fa76661794e8"
 				]
 			}
 		},
 		{
 			"type": "parser",
 			"about": "#0, sub-test #2 storing of one subobject (subobject smw data)",
-			"subject": "Scribunto/subobject/001/0#_86e73ba4007c05bcb66e9a6824567241",
+			"subject": "Scribunto/subobject/001/0#_632434fc58dfec64d856fa76661794e8",
 			"store": {
 				"clear-cache": true
 			},
@@ -121,15 +121,15 @@
 			},
 			"assert-output": {
 				"to-contain": [
-					"Scribunto/subobject/001/1#_752345ba7643e7b56fbaf5ca045efbdd",
-					"Scribunto/subobject/001/1#_b0edeea70a7d0208259ef103503230b3"
+					"Scribunto/subobject/001/1#_f6deea740677460455e132e3366f41c6",
+					"Scribunto/subobject/001/1#_967a45fddee88545cd3f44599bad1a92"
 				]
 			}
 		},
 		{
 			"type": "parser",
 			"about": "#1, sub-test #2 storing of two subobjects (subobject#1 smw data)",
-			"subject": "Scribunto/subobject/001/1#_752345ba7643e7b56fbaf5ca045efbdd",
+			"subject": "Scribunto/subobject/001/1#_f6deea740677460455e132e3366f41c6",
 			"store": {
 				"clear-cache": true
 			},
@@ -152,7 +152,7 @@
 		{
 			"type": "parser",
 			"about": "#1, sub-test #3 storing of two subobjects (subobject#2 smw data)",
-			"subject": "Scribunto/subobject/001/1#_b0edeea70a7d0208259ef103503230b3",
+			"subject": "Scribunto/subobject/001/1#_967a45fddee88545cd3f44599bad1a92",
 			"store": {
 				"clear-cache": true
 			},

--- a/tests/phpunit/Unit/LibraryFactoryTest.php
+++ b/tests/phpunit/Unit/LibraryFactoryTest.php
@@ -40,6 +40,11 @@ class LibraryFactoryTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$mStripState = $this->getMockBuilder( '\StripState' )
+			->disableOriginalConstructor()
+			->getMock();
+		$this->parser->mStripState = $mStripState;
+
 		$this->parser->expects( $this->any() )
 			->method( 'getTitle' )
 			->will( $this->returnValue( \Title::newFromText( 'Foo' ) ) );

--- a/tests/phpunit/Unit/ScribuntoLuaLibrarySetTest.php
+++ b/tests/phpunit/Unit/ScribuntoLuaLibrarySetTest.php
@@ -51,7 +51,7 @@ class ScribuntoLuaLibrarySetTest extends ScribuntoLuaEngineTestBase {
 	 * @return array
 	 */
 	public function dataProviderSetTest() {
-		$provider = [
+		return [
 			[
 				null,
 				[ 1 => true ]
@@ -69,12 +69,12 @@ class ScribuntoLuaLibrarySetTest extends ScribuntoLuaEngineTestBase {
 				[ 1 => true ]
 			],
 			[
-				[ 'has type=page' ],
+				[ 'has text=test' ],
 				[ 1 => true ]
 			],
 			[
 				[ 'has type=test' ],
-				[ [ 1 => false, 'error' => wfMessage('smw_unknowntype')->inLanguage('en')->plain() ] ]
+				[ [ 1 => false, 'error' => wfMessage('smw-datavalue-property-restricted-declarative-use', 'Has type')->inLanguage('en')->plain() ] ]
 			],
 			[
 				[ '1215623e790d918773db943232068a93b21c9f1419cb85666c6558e87f5b7d47=test' ],
@@ -85,7 +85,5 @@ class ScribuntoLuaLibrarySetTest extends ScribuntoLuaEngineTestBase {
 				[ 1 => true ]
 			]
 		];
-
-		return $provider;
 	}
 }

--- a/tests/phpunit/Unit/ScribuntoLuaLibrarySubobjectTest.php
+++ b/tests/phpunit/Unit/ScribuntoLuaLibrarySubobjectTest.php
@@ -66,15 +66,15 @@ class ScribuntoLuaLibrarySubobjectTest extends ScribuntoLuaEngineTestBase {
 				[ 1 => true ]
 			],
 			[
-				[ [ 'has type=page', 'Allows value=test' ] ],
+				[ [ 'has text=test', 'Is bool=true' ] ],
 				[ 1 => true ]
 			],
 			[
-				[ [ 'has type=test', 'Allows value=test' ] ],
-				[ [ 1 => false, 'error' => wfMessage('smw_unknowntype')->inLanguage('en')->plain() ] ]
+				[ [ 'has type=test', 'Is bool=true' ] ],
+				[ [ 1 => false, 'error' => wfMessage('smw-datavalue-property-restricted-declarative-use', 'Has type')->inLanguage('en')->plain() ] ]
 			],
 			[
-				[ [ 'has type=page', 'Allows value=test','1215623e790d918773db943232068a93b21c9f1419cb85666c6558e87f5b7d47=test' ] ],
+				[ [ 'has text=test', 'Is bool=true','1215623e790d918773db943232068a93b21c9f1419cb85666c6558e87f5b7d47=test' ] ],
 				[ 1 => true ]
 			],
 			[
@@ -90,15 +90,15 @@ class ScribuntoLuaLibrarySubobjectTest extends ScribuntoLuaEngineTestBase {
 				[ 1 => true ]
 			],
 			[
-				[ [ 'has type=page', 'Allows value=test' ], '01234567890_testStringAsId' ],
+				[ [ 'has text=test', 'Is bool=true' ], '01234567890_testStringAsId' ],
 				[ 1 => true ]
 			],
 			[
 				[ [ 'has type=test', 'Allows value=test' ], '01234567890_testStringAsId' ],
-				[ [ 1 => false, 'error' => wfMessage('smw_unknowntype')->inLanguage('en')->plain() ] ]
+				[ [ 1 => false, 'error' => wfMessage('smw-datavalue-property-restricted-declarative-use', 'Has type')->inLanguage('en')->plain() . ' ' . wfMessage('smw-datavalue-property-restricted-declarative-use', 'Allows value')->inLanguage('en')->plain() ] ]
 			],
 			[
-				[ [ 'has type=page', 'Allows value' => 'test','1215623e790d918773db943232068a93b21c9f1419cb85666c6558e87f5b7d47=test' ], '01234567890_testStringAsId' ],
+				[ [ 'has text=test', 'Is bool=true' => 'test','1215623e790d918773db943232068a93b21c9f1419cb85666c6558e87f5b7d47=test' ], '01234567890_testStringAsId' ],
 				[ 1 => true ]
 			],
 		];

--- a/tests/phpunit/Unit/mw.smw.set.tests.lua
+++ b/tests/phpunit/Unit/mw.smw.set.tests.lua
@@ -16,7 +16,7 @@ local tests = {
 		expect = { true }
 	},
 	{ name = 'set (matching input type to property type)', func = mw.smw.set,
-		args = { 'has type=page' },
+		args = { 'has text=test' },
 		expect = { true }
 	},
 	{ name = 'set (supplying wrong input type to property type)', func = mw.smw.set,
@@ -24,7 +24,7 @@ local tests = {
 		expect = {
 			{
 				false,
-				error = mw.message.new('smw_unknowntype'):inLanguage('en'):plain()
+				error = mw.message.new('smw-datavalue-property-restricted-declarative-use', 'Has type'):inLanguage('en'):plain()
 			}
 		}
 	},

--- a/tests/phpunit/Unit/mw.smw.subobject.tests.lua
+++ b/tests/phpunit/Unit/mw.smw.subobject.tests.lua
@@ -16,22 +16,23 @@ local tests = {
 		expect = { true }
 	},
 	{ name = 'subobject (matching input types to property types)', func = mw.smw.subobject,
-		args = { { 'Has type=page', ['Allows value'] = 'test' } },
+		args = { { 'Has text=test', ['Is bool'] = 'true' } },
 		expect = { true }
 	},
 
 	{ name = 'subobject (supplying a wrong input type to property type)', func = mw.smw.subobject,
-		args = { { 'Has type=test', ['Allows value'] = 'test' } },
+		args = { { 'Has type=test', ['Is bool'] = 'true' } },
 		expect = {
 			{
 				false,
-				error = mw.message.new('smw_unknowntype'):inLanguage('en'):plain()
+				error = mw.message.new('smw-datavalue-property-restricted-declarative-use', 'Has type'):inLanguage('en'):plain()
+				--error = mw.message.new('smw_unknowntype'):inLanguage('en'):plain()
 				-- should be error = mw.message.new('smw_unknowntype'):inLanguage(mw.getContentLanguage()):plain()
 			}
 		}
 	},
 	{ name = 'subobject (assigning data to non existing property)', func = mw.smw.subobject,
-		args = { { 'Has type=page', ['Allows value'] = 'test' , 'foo=test' } },
+		args = { { 'Has text=test', ['Is bool'] = 'true' , 'foo=test' } },
 		expect = { true }
 	},
 	{ name = 'subobject (no argument, supplying id)', func = mw.smw.subobject,
@@ -39,7 +40,7 @@ local tests = {
 		expect = { true }
 	},
 	{ name = 'subobject (matching input types to property types, supplying id)', func = mw.smw.subobject,
-		args = { { 'Has type=page', ['Allows value'] = 'test' }, '0123456780_teststringAsId' },
+		args = { { 'Has text=test', ['Is bool'] = 'true' }, '0123456780_teststringAsId' },
 		expect = { true }
 	},
 
@@ -48,13 +49,15 @@ local tests = {
 		expect = {
 			{
 				false,
-				error = mw.message.new('smw_unknowntype'):inLanguage('en'):plain()
+				error = mw.message.new('smw-datavalue-property-restricted-declarative-use', 'Has type'):inLanguage('en'):plain()
+					.. ' ' .. mw.message.new('smw-datavalue-property-restricted-declarative-use', 'Allows value'):inLanguage('en'):plain()
+				-- error = mw.message.new('smw_unknowntype'):inLanguage('en'):plain()
 				-- should be error = mw.message.new('smw_unknowntype'):inLanguage(mw.getContentLanguage()):plain()
 			}
 		}
 	},
 	{ name = 'subobject (assigning data to non existing property, supplying id)', func = mw.smw.subobject,
-		args = { { 'Has type=page', ['Allows value'] = 'test' , 'foo=test' }, '0123456780_teststringAsId' },
+		args = { { 'Has text=test', ['Is bool'] = 'true' , 'foo=test' }, '0123456780_teststringAsId' },
 		expect = { true }
 	},
 }

--- a/tests/travis/install-semantic-scribunto.sh
+++ b/tests/travis/install-semantic-scribunto.sh
@@ -8,6 +8,13 @@ MW_INSTALL_PATH=$BASE_PATH/../mw
 function installToMediaWikiRoot {
 	echo -e "Running MW root composer install build on $TRAVIS_BRANCH \n"
 
+	SCRIB="dev-$MW"
+
+	if [ "$MW" = "master" ]
+	then
+	    SCRIB="dev-REL1_30"
+	fi
+
 	cd $MW_INSTALL_PATH
 
 	if [ "$PHPUNIT" != "" ]
@@ -19,11 +26,11 @@ function installToMediaWikiRoot {
 
 	if [ "$SSC" != "" ]
 	then
-		composer require 'mediawiki/scribunto=*' --update-with-dependencies
-		composer require 'mediawiki/semantic-scribunto='$SSC --update-with-dependencies
+		composer require mediawiki/scribunto "$SCRIB" --update-with-dependencies
+		composer require mediawiki/semantic-scribunto "$SSC" --update-with-dependencies
 	else
 		composer init --stability dev
-		composer require mediawiki/scribunto "dev-master" --dev --update-with-dependencies
+		composer require mediawiki/scribunto "$SCRIB" --dev --update-with-dependencies
 		composer require mediawiki/semantic-scribunto "dev-master" --dev --update-with-dependencies
 
 		cd extensions


### PR DESCRIPTION
corrected the failing tests and adapted `./tests/travis/install-semantic-scribunto.sh` to fix scribunto installation via composer, addressing issue #39 