### PR TITLE
fix #48 (mw.set drops property names with numbers in key-value mode)

### DIFF
--- a/src/ScribuntoLuaLibrary.php
+++ b/src/ScribuntoLuaLibrary.php
@@ -353,7 +353,7 @@ class ScribuntoLuaLibrary extends Scribunto_LuaLibraryBase {
 		// we rectify this here
 		$processedArguments = [];
 		foreach ( $arguments as $key => $value ) {
-			if ( !is_int( $key ) && !preg_match( '/[0-9]+/', $key ) ) {
+			if ( !is_int( $key ) && !preg_match( '/^[0-9]+$/', $key ) ) {
 				$value = (string) $key . '=' . (string) $value;
 			}
 			$processedArguments[] = $value;

--- a/tests/phpunit/Integration/JSONScript/Fixtures/module.i48.lua
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/module.i48.lua
@@ -1,0 +1,16 @@
+-- module used for issue #48: https://github.com/SemanticMediaWiki/SemanticScribunto/issues/48
+
+local p = {}
+
+function p.setup()
+    local settings = {
+        ['hello'] = 'world',
+        ['hell0'] = 'world',
+        'HELLO=WORLD',
+        'HELL0=WORLD',
+    }
+    local result = mw.smw.set(settings)
+    return result and 'success' or result.error
+end
+
+return p

--- a/tests/phpunit/Integration/JSONScript/TestCases/set-006.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/set-006.json
@@ -1,0 +1,106 @@
+{
+	"description": "Test issue #48: smw.set drops properties with numbers when using key-value pair method",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "HELL0",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "HELLO",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Hello",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Hell0",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "NS_MODULE",
+			"page": "SetTest",
+			"contents": {
+				"import-from": "/../Fixtures/module.i48.lua"
+			}
+		},
+		{
+			"page": "Scribunto/set/006/0",
+			"contents": "{{#set: HELLO=WORLD|HELL0=WORLD|hello=world|hell0=world}}"
+		},
+		{
+			"page": "Scribunto/set/006/1",
+			"contents": "{{#invoke:SetTest|setup}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 semantic data manually",
+			"subject": "Scribunto/set/006/0",
+			"store": {
+				"clear-cache": true
+			},
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 6,
+					"propertyKeys": [
+						"_MDAT",
+						"_SKEY",
+						"HELL0",
+						"HELLO",
+						"Hello",
+						"Hell0"
+					],
+					"propertyValues": [
+						"WORLD",
+						"world"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 semantic data via mw.smw.set",
+			"subject": "Scribunto/set/006/1",
+			"store": {
+				"clear-cache": true
+			},
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 6,
+					"propertyKeys": [
+						"_MDAT",
+						"_SKEY",
+						"HELL0",
+						"HELLO",
+						"Hello",
+						"Hell0"
+					],
+					"propertyValues": [
+						"WORLD",
+						"world"
+					]
+				}
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		]
+	},
+	"meta": {
+		"version": "1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
adds:
- a test, including fixture, to reproduce the problem
- a fix for the problem (regular expressions and I are still at odds, it seems)

closes #48