### PR TITLE
Add support for `extension.json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,19 @@ Semantic Scribunto (a.k.a. SSC) is a [Semantic Mediawiki][smw] extension to prov
 
 ## Requirements
 
-- PHP 5.5 or later
+- PHP 5.6 or later
 - MediaWiki 1.27 or later
 - [Semantic MediaWiki][smw] 2.4 or later
 
 ## Installation
 
-The recommended way to install Semantic Scribunto is by using [Composer][composer] with an entry in MediaWiki's "composer.json" or preferably "composer.local.json" file:
+The recommended way to install Semantic Scribunto is by using [Composer][composer].
 
+1. Installing the sources via composer can be done in one of two ways:
+    - Either execute from your MediaWiki installation directory:
+   `composer require mediawiki/semantic-scribunto:~1.2`
+    - (recommended) Or add an entry to MediaWiki's "composer.json" or preferably "composer.local.json" file.
+    Afterwards run `composer update --no-dev`.
 ```json
 {
 	"require": {
@@ -26,10 +31,12 @@ The recommended way to install Semantic Scribunto is by using [Composer][compose
 	}
 }
 ```
-1. From your MediaWiki installation directory, execute
-   `composer require mediawiki/semantic-scribunto:~1.1`
-2. Navigate to _Special:Version_ on your wiki and verify that the package
-   have been successfully installed.
+2. Edit your LocalSettings.php and add the line
+```php
+   wfLoadExtension( 'SemanticScribunto' );
+```
+3. Navigate to _Special:Version_ on your wiki and verify that the extension
+   has been successfully installed.
 
 ## Usage
 

--- a/SemanticScribunto.php
+++ b/SemanticScribunto.php
@@ -7,15 +7,6 @@ use SMW\Scribunto\HookRegistry;
  *
  * @defgroup SemanticScribunto Semantic Scribunto
  */
-if ( !defined( 'MEDIAWIKI' ) ) {
-	die( 'This file is part of the Semantic Scribunto extension. It is not a valid entry point.' );
-}
-
-if ( defined( 'SMW_SCRIBUNTO_VERSION' ) ) {
-	// Do not initialize more than once.
-	return 1;
-}
-
 SemanticScribunto::load();
 
 /**
@@ -35,36 +26,15 @@ class SemanticScribunto {
 		if ( is_readable( __DIR__ . '/vendor/autoload.php' ) ) {
 			include_once __DIR__ . '/vendor/autoload.php';
 		}
-
-		// In case extension.json is being used, the succeeding steps will
-		// be handled by the ExtensionRegistry
-		self::initExtension();
-
-		$GLOBALS['wgExtensionFunctions'][] = function() {
-			self::onExtensionFunction();
-		};
 	}
 
 	/**
 	 * @since 1.0
 	 */
-	public static function initExtension() {
+	public static function initExtension( $credits = array() ) {
 
-		define( 'SMW_SCRIBUNTO_VERSION', '1.3.0-alpha' );
-
-		// Register extension info
-		$GLOBALS['wgExtensionCredits']['semantic'][] = [
-			'path'           => __FILE__,
-			'name'           => 'Semantic Scribunto',
-			'author'         => [
-				'James Hong Kong',
-				'[https://www.semantic-mediawiki.org/wiki/User:Oetterer Tobias Oetterer]',
-			],
-			'url'            => 'https://github.com/SemanticMediaWiki/SemanticScribunto/',
-			'descriptionmsg' => 'smw-scribunto-desc',
-			'version'        => SMW_SCRIBUNTO_VERSION,
-			'license-name'   => 'GPL-2.0-or-later'
-		];
+		// See https://phabricator.wikimedia.org/T151136
+		define( 'SMW_SCRIBUNTO_VERSION', isset( $credits['version'] ) ? $credits['version'] : 'UNKNOWN' );
 
 		// Register message files
 		$GLOBALS['wgMessagesDirs']['SemanticScribunto'] = __DIR__ . '/i18n';
@@ -73,29 +43,24 @@ class SemanticScribunto {
 	/**
 	 * @since 1.0
 	 */
-	public static function doCheckRequirements() {
+	public static function onExtensionFunction() {
 
-		if ( version_compare( $GLOBALS[ 'wgVersion' ], '1.27', 'lt' ) ) {
-			die( '<b>Error:</b> <a href="https://github.com/SemanticMediaWiki/SemanticScribunto/">Semantic Scribunto</a> is only compatible with MediaWiki 1.26 or above. You need to upgrade MediaWiki first.' );
+		if ( !defined( 'SMW_VERSION' ) ) {
+			if ( PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg' ) {
+				die( "\nThe 'Semantic Scribunto' extension requires 'Semantic MediaWiki' to be installed and enabled.\n" );
+			} else {
+				die( '<b>Error:</b> The <a href="https://github.com/SemanticMediaWiki/SemanticScribunto/">Semantic Scribunto</a> extension requires <a href="https://www.semantic-mediawiki.org/wiki/Semantic_MediaWiki">Semantic MediaWiki</a> to be installed and enabled.<br />' );
+			}
 		}
 
 		// Using the constant as indicator to avoid class_exists
 		if ( !defined( 'CONTENT_MODEL_SCRIBUNTO' ) ) {
-			die( '<b>Error:</b> <a href="https://github.com/SemanticMediaWiki/SemanticScribunto/">Semantic Scribunto</a> requires <a href="https://www.mediawiki.org/wiki/Extension:Scribunto">Scribunto</a>. Please enable or install the extension first.' );
+			if ( PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg' ) {
+				die( "\nThe 'Semantic Scribunto' extension requires the 'Scribunto' extension to be installed and enabled.\n" );
+			} else {
+				die( '<b>Error:</b> <a href="https://github.com/SemanticMediaWiki/SemanticScribunto/">Semantic Scribunto</a> requires <a href="https://www.mediawiki.org/wiki/Extension:Scribunto">Scribunto</a>. Please install and enable the extension first.<br />' );
+			}
 		}
-
-		if ( !defined( 'SMW_VERSION' ) ) {
-			die( '<b>Error:</b> <a href="https://github.com/SemanticMediaWiki/SemanticScribunto/">Semantic Scribunto</a> requires <a href="https://github.com/SemanticMediaWiki/SemanticMediaWiki/">Semantic MediaWiki</a>. Please enable or install the extension first.' );
-		}
-	}
-
-	/**
-	 * @since 1.0
-	 */
-	public static function onExtensionFunction() {
-
-		// Check requirements after LocalSetting.php has been processed
-		self::doCheckRequirements();
 
 		$hookRegistry = new HookRegistry();
 		$hookRegistry->register();

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 		"source": "https://github.com/SemanticMediaWiki/SemanticScribunto"
 	},
 	"require": {
-		"php": ">=5.5",
+		"php": ">=5.6",
 		"composer/installers": "1.*,>=1.0.1",
 		"mediawiki/semantic-media-wiki": "~2.4|~3.0"
 	},
@@ -58,6 +58,7 @@
 	},
 	"scripts":{
 		"phpunit": "php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist",
+		"test": "php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist",
 		"unit": "composer phpunit -- --testsuite semantic-scribunto-unit",
 		"integration": "composer phpunit -- --testsuite semantic-scribunto-integration",
 		"cs": [

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ you with full control over your returned data, giving you abundant information b
 
 In other words:
 * `ask` is a quick and easy way to get data which is already pre-processed and may not suite your needs entirely.
-However it utilizes native SMW functionality like printout formatting (see [smwdoc] for more information)
+However, it utilizes native SMW functionality like printout formatting (see [smwdoc] for more information)
 * `getQueryResult` gets you the full result set in the same format provided by the [api]
 
 For more information see the sample results in [`mw.smw.ask`][doc.ask] and [`mw.smw.getQueryResult`][doc.getQueryResult].

--- a/extension.json
+++ b/extension.json
@@ -1,0 +1,27 @@
+{
+	"name": "SemanticScribunto",
+	"version": "2.0.0-alpha",
+	"author": [
+		"James Hong Kong",
+		"[https://www.semantic-mediawiki.org/wiki/User:Oetterer Tobias Oetterer]"
+	],
+	"url": "https://github.com/SemanticMediaWiki/SemanticScribunto/",
+	"descriptionmsg": "smw-scribunto-desc",
+	"namemsg": "smw-scribunto-title",
+	"license-name": "GPL-2.0-or-later",
+	"type": "semantic",
+	"requires": {
+		"MediaWiki": ">= 1.27"
+	},
+	"MessagesDirs": {
+		"SemanticScribunto": [
+			"i18n"
+		]
+	},
+	"callback": "SemanticScribunto::initExtension",
+	"ExtensionFunctions": [
+		"SemanticScribunto::onExtensionFunction"
+	],
+	"load_composer_autoloader":true,
+	"manifest_version": 1
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -5,5 +5,6 @@
 			"Kghbln"
 		]
 	},
-	"smw-scribunto-desc": "A Semantic MediaWiki extension to natively support the Scribunto extension"
+	"smw-scribunto-desc": "A Semantic MediaWiki extension to natively support the Scribunto extension",
+	"smw-scribunto-title": "Semantic Scribunto"
 }

--- a/tests/travis/install-semantic-scribunto.sh
+++ b/tests/travis/install-semantic-scribunto.sh
@@ -77,9 +77,10 @@ function updateConfiguration {
 	echo '$wgShowSQLErrors = true;' >> LocalSettings.php
 	echo '$wgDebugDumpSql = false;' >> LocalSettings.php
 	echo '$wgShowDBErrorBacktrace = true;' >> LocalSettings.php
-	
+
 	# SMW#1732
 	echo 'wfLoadExtension( "SemanticMediaWiki" );' >> LocalSettings.php
+	echo 'wfLoadExtension( "SemanticScribunto" );' >> LocalSettings.php
 
 	php maintenance/update.php --quick
 }


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Adds support for `extension.json` and hereby the requirement to use `wfLoadExtension( 'SemanticScribunto' );` in the `LocalSettings.php`
- PHP 5.6 as min requirement 
- Switches to 2.0.0-alpha as version

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
