### PR TITLE
travis: load Scribunto via extension registration

### DIFF
--- a/tests/travis/install-semantic-scribunto.sh
+++ b/tests/travis/install-semantic-scribunto.sh
@@ -66,7 +66,7 @@ function updateConfiguration {
 		echo '$wgLanguageCode = "'$SITELANG'";' >> LocalSettings.php
 	fi
 
-	echo 'require_once "$IP/extensions/Scribunto/Scribunto.php";' >> LocalSettings.php
+	echo 'wfLoadExtension( "Scribunto" );' >> LocalSettings.php
 	echo '$wgScribuntoDefaultEngine = "luastandalone";' >> LocalSettings.php
 
 	# Error reporting


### PR DESCRIPTION
The PHP entry point was removed in [change I525c6e5b1c](https://gerrit.wikimedia.org/r/514730).

This PR is made in reference to: none

This PR addresses or contains:
- CI fix

This PR includes:
- [ ] ~~Tests (unit/integration)~~
- [x] CI build passed

Fixes none