### PR TITLE
[CI] Switch to PHP 7+ and MW 1.31+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,22 @@ language: php
 matrix:
   fast_finish: true
   include:
-    - env: DB=mysql; MW=REL1_27; TYPE=coverage
-      php: 5.6
-    - env: DB=mysql; MW=REL1_27;
-      php: 5.6
-    - env: DB=sqlite; MW=REL1_28; SITELANG=ja
-      php: 5.6
-    - env: DB=sqlite; MW=master; PHPUNIT=4.8.*
+    - env: DB=mysql; MW=REL1_31; TYPE=coverage; PHPUNIT=6.5.*
+      php: 7.0
+    - env: DB=mysql; MW=REL1_32; PHPUNIT=6.5.*
       php: 7.1
+    - env: DB=sqlite; MW=REL1_33; PHPUNIT=6.5.*
+      php: 7.2
+    - env: DB=mysql; MW=REL1_33; PHPUNIT=6.5.*
+      php: 7.2
+    - env: DB=mysql; MW=master; PHPUNIT=6.5.*
+      php: 7.3
   allow_failures:
     # Use of UtfNormal::cleanUp was deprecated in MediaWiki 1.25.
     # [Called from ScribuntoHooks::invokeHook
-    - env: DB=sqlite; MW=master; PHPUNIT=4.8.*
+    - env: DB=mysql; MW=master; PHPUNIT=6.5.*
+    # SQLite failure
+    - env: DB=sqlite; MW=REL1_33; PHPUNIT=6.5.*
 
 install:
   - bash ./tests/travis/install-mediawiki.sh

--- a/tests/phpunit/Integration/JSONScript/SemanticScribuntoJsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/SemanticScribuntoJsonTestCaseScriptRunnerTest.php
@@ -267,7 +267,7 @@ class SemanticScribuntoJsonTestCaseScriptRunnerTest extends JsonTestCaseScriptRu
 			isset( $case['namespace'] ) ? constant( $case['namespace'] ) : NS_MAIN
 		);
 
-		$pageReader = UtilityFactory::getInstance()->newPageReader();
+		$pageReader = $this->testEnvironment->getUtilityFactory()->newPageReader();
 		$parserOutput = $pageReader->getEditInfo( $subject->getTitle() )->getOutput();
 
 		if ( isset( $case['assert-output']['to-contain'] ) ) {

--- a/tests/travis/install-semantic-scribunto.sh
+++ b/tests/travis/install-semantic-scribunto.sh
@@ -24,13 +24,14 @@ function installToMediaWikiRoot {
 		composer require 'phpunit/phpunit=3.7.*' --update-with-dependencies
 	fi
 
+
 	if [ "$SSC" != "" ]
 	then
-		composer require mediawiki/scribunto "$SCRIB" --update-with-dependencies
+	#	composer require mediawiki/scribunto "$SCRIB" --update-with-dependencies
 		composer require mediawiki/semantic-scribunto "$SSC" --update-with-dependencies
 	else
 		composer init --stability dev
-		composer require mediawiki/scribunto "$SCRIB" --dev --update-with-dependencies
+	#	composer require mediawiki/scribunto "$SCRIB" --dev --update-with-dependencies
 		composer require mediawiki/semantic-scribunto "dev-master" --dev --update-with-dependencies
 
 		cd extensions
@@ -52,6 +53,15 @@ function installToMediaWikiRoot {
 		cd ../..
 	fi
 
+	cd extensions
+
+	wget https://github.com/wikimedia/mediawiki-extensions-Scribunto/archive/$MW.tar.gz
+
+	tar -zxf $MW.tar.gz
+	mv mediawiki-extensions-Scribunto* Scribunto
+
+	cd ..
+
 	# Rebuild the class map for added classes during git fetch
 	composer dump-autoload
 }
@@ -66,7 +76,6 @@ function updateConfiguration {
 		echo '$wgLanguageCode = "'$SITELANG'";' >> LocalSettings.php
 	fi
 
-	echo 'require_once "$IP/extensions/Scribunto/Scribunto.php";' >> LocalSettings.php
 	echo '$wgScribuntoDefaultEngine = "luastandalone";' >> LocalSettings.php
 
 	# Error reporting
@@ -81,6 +90,7 @@ function updateConfiguration {
 	# SMW#1732
 	echo 'wfLoadExtension( "SemanticMediaWiki" );' >> LocalSettings.php
 	echo 'wfLoadExtension( "SemanticScribunto" );' >> LocalSettings.php
+	echo 'wfLoadExtension( "Scribunto" );' >> LocalSettings.php
 
 	php maintenance/update.php --quick
 }


### PR DESCRIPTION
This PR is made in reference to: #65

This PR addresses or contains:

- Switches to PHP 7+ and MW 1.31+
- Uses `wfLoadExtension( "Scribunto" )`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #65
