### PR TITLE
[CI] Run with `use-normal-tables` to avoid "Error: 1137 Can't reopen …table ..."

### DIFF
--- a/tests/phpunit/Unit/ScribuntoLuaEngineTestBase.php
+++ b/tests/phpunit/Unit/ScribuntoLuaEngineTestBase.php
@@ -36,4 +36,55 @@ abstract class ScribuntoLuaEngineTestBase extends \Scribunto_LuaEngineTestBase
 	public function getScribuntoLuaLibrary() {
 		return $this->scribuntoLuaLibrary;
 	}
+
+	/**
+	 * Only needed for MW 1.31
+	 */
+	public function run( \PHPUnit_Framework_TestResult $result = null ) {
+		// MW 1.31
+		$this->setCliArg( 'use-normal-tables', true );
+
+		parent::run( $result );
+	}
+
+	/**
+	 * @see Scribunto_LuaEngineTestBase -> MediaWikiTestCase
+	 */
+	protected function overrideMwServices( $configOverrides = null, array $services = [] ) {
+
+		/**
+		 * `MediaWikiTestCase` isolates the result with  `MediaWikiTestResult` which
+		 * ecapsultes the commandline args and since we need to use "real" tables
+		 * as part of "use-normal-tables" we otherwise end-up with the `CloneDatabase`
+		 * to create TEMPORARY  TABLE by default as in:
+		 *
+		 * CREATE TEMPORARY  TABLE `unittest_smw_di_blob` (LIKE `smw_di_blob`) and
+		 * because of the TEMPORARY TABLE, MySQL (not MariaDB) will complain
+		 * about things like:
+		 *
+		 * SELECT p.smw_title AS prop, o_id AS id0, o0.smw_title AS v0, o0.smw_namespace
+		 * AS v1, o0.smw_iw AS v2, o0.smw_sortkey AS v3, o0.smw_subobject AS v4,
+		 * o0.smw_sort AS v5 FROM `unittest_smw_di_wikipage` INNER JOIN
+		 * `unittest_smw_object_ids` AS p ON p_id=p.smw_id INNER JOIN
+		 * `unittest_smw_object_ids` AS o0 ON o_id=o0.smw_id WHERE (s_id='29') AND
+		 * (p.smw_iw!=':smw') AND (p.smw_iw!=':smw-delete')
+		 *
+		 * Function: SMW\SQLStore\EntityStore\SemanticDataLookup::fetchSemanticDataFromTable
+		 * Error: 1137 Can't reopen table: 'p' ()
+		 *
+		 * The reason is that `unittest_smw_object_ids` was created as TEMPORARY TABLE
+		 * and p is referencing to a TEMPORARY TABLE as well which isn't allowed in
+		 * MySQL.
+		 *
+		 * "You cannot refer to a TEMPORARY table more than once in the same query" [0]
+		 *
+		 * [0] https://dev.mysql.com/doc/refman/8.0/en/temporary-table-problems.html
+		 */
+
+		// MW 1.32+
+		$this->setCliArg( 'use-normal-tables', true );
+
+		parent::overrideMwServices( $configOverrides, $services );
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #73

This PR addresses or contains:

- We have to override a couple of methods to ensure `use-normal-tables` is used which tells the `CloneDatabase` ro create "real" tables hereby avoids the issue of TEMP references in TEMPORARY TABLES.

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #73
