### PR TITLE
fix issue 75: set and subobject fail execution when encountering invalid paramter type

### DIFF
--- a/src/mw.smw.lua
+++ b/src/mw.smw.lua
@@ -10,6 +10,39 @@
 -- Variable instantiation
 local smw = {}
 local php
+local valid_value_types = { 'nil', 'boolean', 'string', 'number' }
+
+local function validate_type( var )
+	for k, v in pairs( valid_value_types ) do
+		if type( var ) == v then
+			return true
+		end
+	end
+	return false
+end
+
+local function validate( parameters )
+	if type( parameters ) == 'string' then
+		return true
+	end
+	if type( parameters ) == 'table' then
+		for property, value in pairs( parameters ) do
+			if not validate_type( property ) or not validate_type( value ) then
+				if type( value ) == 'table' then
+					for k, v in pairs( value ) do
+						if not validate_type( k ) or not validate_type( v ) then
+							return false
+						end
+					end
+				else
+					return false
+				end
+			end
+		end
+		return true
+	end
+	return false
+end
 
 function smw.setupInterface()
 	-- Interface setup
@@ -48,11 +81,20 @@ end
 
 -- set
 function smw.set( parameters )
+	if not validate( parameters ) then
+		error( 'Invalid parameter type supplied to smw.set().' )
+	end
 	return php.set( parameters )
 end
 
 -- subobject
 function smw.subobject( parameters, subobjectId )
+	if not validate( parameters ) then
+		error( 'Invalid parameter type supplied to smw.subobject()' )
+	end
+	if not validate_type( subobjectId ) then
+		error( 'Invalid type for subobject id supplied to smw.subobject()' )
+	end
 	return php.subobject( parameters, subobjectId )
 end
 

--- a/tests/phpunit/Integration/JSONScript/Fixtures/module.i75.lua
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/module.i75.lua
@@ -1,0 +1,22 @@
+-- module used for issue #75: https://github.com/SemanticMediaWiki/SemanticScribunto/issues/75
+
+local p = {}
+
+function p.set()
+	local dataStore = {}
+	dataStore['some property'] = mw.text.gsplit('some','strings')
+	mw.smw.set( dataStore )
+end
+
+function p.subobject()
+	local dataStore = {}
+	dataStore['some property'] = mw.text.gsplit('some','strings')
+	mw.smw.subobject( dataStore )
+end
+
+function p.subobjectId()
+	local dataStore = {}
+	mw.smw.subobject( { someData = 'FooBar' }, mw.text.gsplit('some','strings') )
+end
+
+return p

--- a/tests/phpunit/Integration/JSONScript/TestCases/set-008.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/set-008.json
@@ -1,0 +1,42 @@
+{
+	"description": "Test issue #75: mw.smw.set stops execution when encountering invalid input",
+	"setup": [
+		{
+			"namespace": "NS_MODULE",
+			"page": "Issue75",
+			"contents": {
+				"import-from": "/../Fixtures/module.i75.lua"
+			}
+		},
+		{
+			"page": "Scribunto/set/008/0",
+			"contents": "{{#invoke:Issue75|set}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 semantic data foobar to mw.smw.set",
+			"subject": "Scribunto/set/008/0",
+			"store": {
+				"clear-cache": true
+			},
+			"assert-output": {
+				"to-contain": [
+					"class=\"mw-parser-output\"",
+					"class=\"scribunto-error\"",
+					"Lua error in mw.smw.lua at line 85: Invalid parameter type supplied to smw.set()."
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/subobject-003.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/subobject-003.json
@@ -1,0 +1,61 @@
+{
+	"description": "Test issue #75: mw.smw.subobject stops execution when encountering invalid input",
+	"setup": [
+		{
+			"namespace": "NS_MODULE",
+			"page": "Issue75",
+			"contents": {
+				"import-from": "/../Fixtures/module.i75.lua"
+			}
+		},
+		{
+			"page": "Scribunto/subobject/008/0",
+			"contents": "{{#invoke:Issue75|subobject}}"
+		},
+		{
+			"page": "Scribunto/subobject/008/1",
+			"contents": "{{#invoke:Issue75|subobjectId}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 semantic data foobar to mw.smw.subobject",
+			"subject": "Scribunto/subobject/008/0",
+			"store": {
+				"clear-cache": true
+			},
+			"assert-output": {
+				"to-contain": [
+					"class=\"mw-parser-output\"",
+					"class=\"scribunto-error\"",
+					"Lua error in mw.smw.lua at line 93: Invalid parameter type supplied to smw.subobject()."
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 subobject id foobar to mw.smw.subobject",
+			"subject": "Scribunto/subobject/008/1",
+			"store": {
+				"clear-cache": true
+			},
+			"assert-output": {
+				"to-contain": [
+					"class=\"mw-parser-output\"",
+					"class=\"scribunto-error\"",
+					"Lua error in mw.smw.lua at line 96: Invalid type for subobject id supplied to smw.subobject()."
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/ScribuntoLuaEngineTestBase.php
+++ b/tests/phpunit/Unit/ScribuntoLuaEngineTestBase.php
@@ -19,7 +19,7 @@ abstract class ScribuntoLuaEngineTestBase extends \Scribunto_LuaEngineTestBase
 	 */
 	private $scribuntoLuaLibrary;
 
-	protected function setUp() {
+	protected function setUp() : void {
 		parent::setUp();
 
 		/** @noinspection PhpParamsInspection */

--- a/tests/phpunit/Unit/ScribuntoLuaEngineTestBase.php
+++ b/tests/phpunit/Unit/ScribuntoLuaEngineTestBase.php
@@ -50,7 +50,7 @@ abstract class ScribuntoLuaEngineTestBase extends \Scribunto_LuaEngineTestBase
 	/**
 	 * @see Scribunto_LuaEngineTestBase -> MediaWikiTestCase
 	 */
-	protected function overrideMwServices( $configOverrides = null, array $services = [] ) {
+	protected function overrideMwServices( \Config $configOverrides = null, array $services = [] ) {
 
 		/**
 		 * `MediaWikiTestCase` isolates the result with  `MediaWikiTestResult` which

--- a/tests/phpunit/Unit/ScribuntoLuaEngineTestBase.php
+++ b/tests/phpunit/Unit/ScribuntoLuaEngineTestBase.php
@@ -19,7 +19,7 @@ abstract class ScribuntoLuaEngineTestBase extends \Scribunto_LuaEngineTestBase
 	 */
 	private $scribuntoLuaLibrary;
 
-	protected function setUp() : void {
+	protected function setUp() {
 		parent::setUp();
 
 		/** @noinspection PhpParamsInspection */


### PR DESCRIPTION
- add parameter validation to mw.smw.lua
- add integration tests for said fixes
- fix php warning encountered in ScribuntoLuaEngineTestBase

This PR is made in reference to: #75 

This PR addresses or contains:
fixes for said issue

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #75 
