### PR TITLE
Remove unused variable from test case

### DIFF
--- a/tests/phpunit/Integration/JSONScript/Fixtures/module.i75.lua
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/module.i75.lua
@@ -15,7 +15,6 @@ function p.subobject()
 end
 
 function p.subobjectId()
-	local dataStore = {}
 	mw.smw.subobject( { someData = 'FooBar' }, mw.text.gsplit('some','strings') )
 end
 


### PR DESCRIPTION
Since the variable is not used, it probably shouldn't be there. I guess it happened from copy pasting the original function.

This PR is made in reference to: #

This PR addresses or contains:
- ...
- ...
- ...

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #
