### PR TITLE
Add sep example to mw.smw.set.md

### DIFF
--- a/docs/mw.smw.set.md
+++ b/docs/mw.smw.set.md
@@ -42,7 +42,8 @@ function p.inlineSet( frame )
 
     local dataStoreType2 = {
         'my property1=value1',
-        'my property2=value2',
+        'my property2=value2.2,value2.2',
+        '+sep=,',
         'my property3=value3',
     }
 

--- a/docs/mw.smw.set.md
+++ b/docs/mw.smw.set.md
@@ -42,7 +42,7 @@ function p.inlineSet( frame )
 
     local dataStoreType2 = {
         'my property1=value1',
-        'my property2=value2.2,value2.2',
+        'my property2=value2.1,value2.2',
         '+sep=,',
         'my property3=value3',
     }


### PR DESCRIPTION
This PR addresses or contains:
documentation

It was not obvious to me  that the `sep=,` and `template` should be added as the next sibling(s) in the table.
When reading the documentation, I tried the following: 
```
my property2=value2.1,value2.2|+sep=,
```
until looking at https://github.com/SemanticMediaWiki/SemanticScribunto/blob/b81e565b6991b64ff2a1ca5f5f6c004fd1de3fad/tests/phpunit/Integration/JSONScript/Fixtures/module.smw.lua#L71 which has an example using +sep.