### PR TITLE
Fix "mw.smw.ask" for "format=count" queries

### DIFF
--- a/src/ScribuntoLuaLibrary.php
+++ b/src/ScribuntoLuaLibrary.php
@@ -5,6 +5,7 @@ namespace SMW\Scribunto;
 use Scribunto_LuaLibraryBase;
 use SMW\DIProperty;
 use SMW\ApplicationFactory;
+use SMWQuery as Query;
 use SMWQueryResult as QueryResult;
 use SMWOutputs;
 

--- a/src/ScribuntoLuaLibrary.php
+++ b/src/ScribuntoLuaLibrary.php
@@ -62,6 +62,10 @@ class ScribuntoLuaLibrary extends Scribunto_LuaLibraryBase {
 			$this->processLuaArguments( $arguments )
 		);
 
+		if ( $queryResult->getQuery()->getQueryMode() == Query::MODE_COUNT ) {
+			return [ $queryResult->getCountValue() ];
+		}
+
 		if ( !$this->isAQueryResult( $queryResult ) ) {
 			return [ $queryResult ];
 		}


### PR DESCRIPTION
"format=count" is a pseudo result format that requires special handling. Without this patch, "ask" returns nil. Performing a "getQueryResult" and looking at the row count is a possible workaround but it's incredibly inefficient for larger datasets.

This PR is made in reference to: #80

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #80
