### PR TITLE
Fix 'error' bubble type in mw.smw.info

### DIFF
--- a/src/ScribuntoLuaLibrary.php
+++ b/src/ScribuntoLuaLibrary.php
@@ -152,7 +152,7 @@ class ScribuntoLuaLibrary extends Scribunto_LuaLibraryBase {
 		}
 
 		// check if icon is set and valid
-		if ( !is_string( $icon ) || !in_array( $icon, [ 'note', 'warning' ] ) ) {
+		if ( !is_string( $icon ) || !in_array( $icon, [ 'note', 'warning', 'error' ] ) ) {
 			$icon = 'info';
 		}
 

--- a/tests/phpunit/Unit/ScribuntoLuaLibraryInfoTest.php
+++ b/tests/phpunit/Unit/ScribuntoLuaLibraryInfoTest.php
@@ -63,6 +63,10 @@ class ScribuntoLuaLibraryInfoTest extends ScribuntoLuaEngineTestBase {
 		);
 		$this->assertEquals(
 			1,
+			preg_match('~^<span class=.*<span class="[^"]*error">.*>Test info text<.*</span>$~', $this->getScribuntoLuaLibrary()->info( 'Test info text', 'error' )[0])
+		);
+		$this->assertEquals(
+			1,
 			preg_match('~^<span class=.*<span class="[^"]*info">.*>Test info text<.*</span>$~', $this->getScribuntoLuaLibrary()->info( 'Test info text', 'invalid' )[0])
 		);
 	}


### PR DESCRIPTION
This PR is made in reference to: #82

This PR addresses or contains:
- fix the display of `mw.smw.icon` when its type is set to `error`

This PR includes:
- [x] Tests (unit/integration)
- [ ] CI build passed

Fixes #82
