### PR TITLE
PHPUnit_Framework_TestCase is now namespaced

### DIFF
--- a/tests/phpunit/Integration/I18nJsonFileIntegrityTest.php
+++ b/tests/phpunit/Integration/I18nJsonFileIntegrityTest.php
@@ -13,7 +13,7 @@ use SMW\Tests\Utils\UtilityFactory;
  *
  * @author mwjames
  */
-class I18nJsonFileIntegrityTest extends \PHPUnit_Framework_TestCase {
+class I18nJsonFileIntegrityTest extends PHPUnit\Framework\TestCase {
 
 	/**
 	 * @dataProvider i18nFileProvider


### PR DESCRIPTION
PHPUnit started using fully namespaced class names back in v6


This fixes an uncaught fatal error when trying to do `composer phpunit`

```
Fatal error: Uncaught Error: Class "PHPUnit_Framework_TestCase" not found in /opt/htdocs/mediawiki/extensions/SemanticScribunto/tests/phpunit/Integration/I18nJsonFileIntegrityTest.php:16
Stack trace:
#0 /opt/htdocs/mediawiki/vendor/phpunit/phpunit/src/Util/FileLoader.php(66): include_once()
#1 /opt/htdocs/mediawiki/vendor/phpunit/phpunit/src/Util/FileLoader.php(49): PHPUnit\Util\FileLoader::load('/opt/htdocs/med...')
#2 /opt/htdocs/mediawiki/vendor/phpunit/phpunit/src/Framework/TestSuite.php(398): PHPUnit\Util\FileLoader::checkAndLoad('/opt/htdocs/med...')
#3 /opt/htdocs/mediawiki/vendor/phpunit/phpunit/src/Framework/TestSuite.php(537): PHPUnit\Framework\TestSuite->addTestFile('/opt/htdocs/med...')
#4 /opt/htdocs/mediawiki/tests/phpunit/suites/ExtensionsTestSuite.php(39): PHPUnit\Framework\TestSuite->addTestFiles(Array)
#5 /opt/htdocs/mediawiki/tests/phpunit/suites/ExtensionsTestSuite.php(48): ExtensionsTestSuite->__construct()
#6 [internal function]: ExtensionsTestSuite::suite('ExtensionsTestS...')
#7 /opt/htdocs/mediawiki/vendor/phpunit/phpunit/src/Framework/TestSuite.php(486): ReflectionMethod->invoke(NULL, 'ExtensionsTestS...')
#8 /opt/htdocs/mediawiki/vendor/phpunit/phpunit/src/TextUI/TestSuiteMapper.php(84): PHPUnit\Framework\TestSuite->addTestFile('/opt/htdocs/med...')
#9 /opt/htdocs/mediawiki/vendor/phpunit/phpunit/src/TextUI/Command.php(393): PHPUnit\TextUI\TestSuiteMapper->map(Object(PHPUnit\TextUI\XmlConfiguration\TestSuiteCollection), '')
#10 /opt/htdocs/mediawiki/vendor/phpunit/phpunit/src/TextUI/Command.php(114): PHPUnit\TextUI\Command->handleArguments(Array)
#11 /opt/htdocs/mediawiki/vendor/phpunit/phpunit/src/TextUI/Command.php(99): PHPUnit\TextUI\Command->run(Array, true)
#12 /opt/htdocs/mediawiki/vendor/phpunit/phpunit/phpunit(107): PHPUnit\TextUI\Command::main()
#13 /opt/htdocs/mediawiki/vendor/bin/phpunit(122): include('/opt/htdocs/med...')
#14 {main}

Next PHPUnit\TextUI\RuntimeException: Class "PHPUnit_Framework_TestCase" not found in /opt/htdocs/mediawiki/vendor/phpunit/phpunit/src/TextUI/Command.php on line 101

PHPUnit\TextUI\RuntimeException: Class "PHPUnit_Framework_TestCase" not found in /opt/htdocs/mediawiki/vendor/phpunit/phpunit/src/TextUI/Command.php on line 101

Call Stack:
    0.0006     358664   1. {main}() /opt/htdocs/mediawiki/vendor/bin/phpunit:0
    0.0010     359744   2. include('/opt/htdocs/mediawiki/vendor/phpunit/phpunit/phpunit') /opt/htdocs/mediawiki/vendor/bin/phpunit:122
    0.0579     593376   3. PHPUnit\TextUI\Command::main($exit = ???) /opt/htdocs/mediawiki/vendor/phpunit/phpunit/phpunit:107

Script phpunit handling the phpunit event returned with error code 255
```