### PR TITLE
Use namespaced Linker class if available

### DIFF
--- a/src/LuaAskResultProcessor.php
+++ b/src/LuaAskResultProcessor.php
@@ -169,8 +169,14 @@ class LuaAskResultProcessor {
 				$value = ( $value == (int)$value ) ? intval( $value ) : $value;
 				break;
 			default:
+				if ( class_exists( 'MediaWiki\\Linker\\Linker' ) ) {
+					// MW 1.40+
+					$linker = new \MediaWiki\Linker\Linker();
+				} else {
+					$linker = new \Linker();
+				}
 				# FIXME ignores parameter link=none|subject
-				$value = $dataValue->getShortText( SMW_OUTPUT_WIKI, new \Linker() );
+				$value = $dataValue->getShortText( SMW_OUTPUT_WIKI, $linker );
 		}
 
 		return $value;


### PR DESCRIPTION
This PR is made in reference to: #111

This PR addresses or contains:
- Fix compatibility with MW 1.44 by using the namespaced Linker class if it is available. The class alias for the non-namespaced Linker was removed in 1.44.

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #111
