### PR TITLE
Use namespaced class names from MediaWiki, Scribunto, and SMW

### DIFF
--- a/src/LibraryFactory.php
+++ b/src/LibraryFactory.php
@@ -2,17 +2,17 @@
 
 namespace SMW\Scribunto;
 
-use Parser;
+use MediaWiki\Parser\Parser;
 use SMW\ParameterProcessorFactory;
 use SMW\ParserFunctions\SetParserFunction;
 use SMW\ParserFunctions\SubobjectParserFunction;
 use SMW\ParserParameterProcessor;
+use SMW\Query\Query;
 use SMW\Query\QueryContext;
+use SMW\Query\QueryProcessor;
 use SMW\Query\QueryResult;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Store;
-use SMWQuery as Query;
-use SMWQueryProcessor as QueryProcessor;
 
 /**
  * @license GPL-2.0-or-later
@@ -38,7 +38,7 @@ class LibraryFactory {
 
 	/**
 	 * Creates a new QueryResult from passed arguments,
-	 * utilizing the {@see SMWQueryProcessor}.
+	 * utilizing the {@see QueryProcessor}.
 	 *
 	 * Note: SMW's Store::getQueryResult() returns a debug-output string rather
 	 * than a QueryResult when the query uses `format=debug` (and a handful of
@@ -63,7 +63,7 @@ class LibraryFactory {
 			$printouts
 		);
 
-		if ( defined( 'SMWQuery::PROC_CONTEXT' ) ) {
+		if ( defined( Query::class . '::PROC_CONTEXT' ) ) {
 			$query->setOption( Query::PROC_CONTEXT, 'SSC.LibraryFactory' );
 		}
 

--- a/src/LuaAskResultProcessor.php
+++ b/src/LuaAskResultProcessor.php
@@ -3,10 +3,11 @@
 namespace SMW\Scribunto;
 
 use MediaWiki\Linker\Linker;
+use SMW\DataValues\DataValue;
+use SMW\DataValues\NumberValue;
 use SMW\Query\PrintRequest;
 use SMW\Query\QueryResult;
 use SMW\Query\Result\ResultArray;
-use SMWDataValue as DataValue;
 
 /**
  * Class LuaAskResultProcessor
@@ -160,7 +161,7 @@ class LuaAskResultProcessor {
 				break;
 			case '_num':
 				// number value found
-				/** @var \SMWNumberValue $dataValue */
+				/** @var NumberValue $dataValue */
 				$value = $dataValue->getNumber();
 				$value = ( $value == (int)$value ) ? intval( $value ) : $value;
 				break;

--- a/src/ScribuntoLuaLibrary.php
+++ b/src/ScribuntoLuaLibrary.php
@@ -3,11 +3,11 @@
 namespace SMW\Scribunto;
 
 use MediaWiki\Extension\Scribunto\Engines\LuaCommon\LibraryBase;
-use SMW\DIProperty;
+use SMW\DataItems\Property;
+use SMW\MediaWiki\Outputs;
 use SMW\Query\QueryContext;
 use SMW\Query\QueryResult;
 use SMW\Services\ServicesFactory as ApplicationFactory;
-use SMWOutputs;
 
 /**
  * @license GPL-2.0-or-later
@@ -98,7 +98,7 @@ class ScribuntoLuaLibrary extends LibraryBase {
 			return [ null ];
 		}
 
-		$property = DIProperty::newFromUserLabel( $propertyName );
+		$property = Property::newFromUserLabel( $propertyName );
 
 		if ( $property === null ) {
 			return [ null ];
@@ -167,8 +167,8 @@ class ScribuntoLuaLibrary extends LibraryBase {
 			false // No escaping.
 		);
 
-		// to have all necessary data committed to output, use SMWOutputs::commitToParser()
-		SMWOutputs::commitToParser(
+		// to have all necessary data committed to output, use Outputs::commitToParser()
+		Outputs::commitToParser(
 			$this->getEngine()->getParser()
 		);
 

--- a/tests/phpunit/Integration/I18nJsonFileIntegrityTest.php
+++ b/tests/phpunit/Integration/I18nJsonFileIntegrityTest.php
@@ -2,6 +2,7 @@
 
 namespace SMW\Scribunto\Tests\Integration;
 
+use PHPUnit\Framework\TestCase;
 use SMW\Tests\Utils\UtilityFactory;
 
 /**
@@ -13,7 +14,7 @@ use SMW\Tests\Utils\UtilityFactory;
  *
  * @author mwjames
  */
-class I18nJsonFileIntegrityTest extends \PHPUnit\Framework\TestCase {
+class I18nJsonFileIntegrityTest extends TestCase {
 
 	/**
 	 * @dataProvider i18nFileProvider

--- a/tests/phpunit/Unit/LuaAskResultProcessorTest.php
+++ b/tests/phpunit/Unit/LuaAskResultProcessorTest.php
@@ -3,12 +3,12 @@
 namespace SMW\Scribunto\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
+use SMW\DataValues\NumberValue;
 use SMW\DataValues\StringValue;
 use SMW\Query\PrintRequest;
 use SMW\Query\QueryResult;
 use SMW\Query\Result\ResultArray;
 use SMW\Scribunto\LuaAskResultProcessor;
-use SMWNumberValue;
 
 /**
  * @covers \SMW\Scribunto\LuaAskResultProcessor
@@ -244,7 +244,7 @@ class LuaAskResultProcessorTest extends TestCase {
 	 */
 	public function dataProviderGetValueFromDataValueTest() {
 		return [
-			[ SMWNumberValue::class, '_num', 'assertIsInt' ],
+			[ NumberValue::class, '_num', 'assertIsInt' ],
 			[ \SMWWikiPageValue::class, '_wpg', 'assertNull' ],
 			[ StringValue::class, '_boo', 'assertIsBool' ],
 			[ \SMWTimeValue::class, '_dat', 'assertNull' ],
@@ -302,10 +302,10 @@ class LuaAskResultProcessorTest extends TestCase {
 	}
 
 	/**
-	 * Constructs a mock {@see \SMWNumberValue}
+	 * Constructs a mock {@see NumberValue}
 	 */
 	private function constructSMWNumberValue() {
-		$printRequest = $this->getMockBuilder( SMWNumberValue::class )
+		$printRequest = $this->getMockBuilder( NumberValue::class )
 			->setConstructorArgs( [ '_num' ] )
 			->getMock();
 

--- a/tests/phpunit/Unit/ScribuntoLuaEngineTestBase.php
+++ b/tests/phpunit/Unit/ScribuntoLuaEngineTestBase.php
@@ -2,12 +2,13 @@
 
 namespace SMW\Scribunto\Tests\Unit;
 
+use MediaWiki\Config\Config;
+use MediaWiki\Extension\Scribunto\Tests\Engines\LuaCommon\LuaEngineTestBase;
 use PHPUnit\Framework\TestResult;
-use Scribunto_LuaEngineTestBase;
 use SMW\Scribunto\ScribuntoLuaLibrary;
 
 /**
- * Encapsulation of the Scribunto_LuaEngineTestBase class
+ * Encapsulation of the LuaEngineTestBase class
  *
  * @group Test
  * @group Database
@@ -17,7 +18,7 @@ use SMW\Scribunto\ScribuntoLuaLibrary;
  *
  * @author mwjames
  */
-abstract class ScribuntoLuaEngineTestBase extends Scribunto_LuaEngineTestBase {
+abstract class ScribuntoLuaEngineTestBase extends LuaEngineTestBase {
 	/**
 	 * @var ScribuntoLuaLibrary
 	 */
@@ -56,9 +57,9 @@ abstract class ScribuntoLuaEngineTestBase extends Scribunto_LuaEngineTestBase {
 	}
 
 	/**
-	 * @see Scribunto_LuaEngineTestBase -> MediaWikiTestCase
+	 * @see LuaEngineTestBase -> MediaWikiIntegrationTestCase
 	 */
-	protected function overrideMwServices( \Config $configOverrides = null, array $services = [] ) {
+	protected function overrideMwServices( ?Config $configOverrides = null, array $services = [] ) {
 		/**
 		 * `MediaWikiTestCase` isolates the result with  `MediaWikiTestResult` which
 		 * ecapsultes the commandline args and since we need to use "real" tables


### PR DESCRIPTION
## Summary

Replace legacy global-namespace class names with their canonical namespaced equivalents. Each replacement verified against MediaWiki 1.43 (the declared minimum in `extension.json`), Scribunto REL1_43, and [SMW's 7.0.0 deprecations](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/releasenotes/RELEASE-NOTES-7.0.0.md).

| Legacy                           | Namespaced                                                            |
| -------------------------------- | --------------------------------------------------------------------- |
| `Parser`                         | `MediaWiki\Parser\Parser`                                             |
| `Config`                         | `MediaWiki\Config\Config`                                             |
| `SMW\DIProperty`                 | `SMW\DataItems\Property`                                              |
| `SMWOutputs`                     | `SMW\MediaWiki\Outputs`                                               |
| `SMWQuery`                       | `SMW\Query\Query`                                                     |
| `SMWQueryProcessor`              | `SMW\Query\QueryProcessor`                                            |
| `SMWDataValue`                   | `SMW\DataValues\DataValue`                                            |
| `SMWNumberValue`                 | `SMW\DataValues\NumberValue`                                          |
| `Scribunto_LuaEngineTestBase`    | `MediaWiki\Extension\Scribunto\Tests\Engines\LuaCommon\LuaEngineTestBase` |

The `defined()` runtime guard in `LibraryFactory::newQueryResultFrom` switches from the legacy string `'SMWQuery::PROC_CONTEXT'` to `` `Query::class . '::PROC_CONTEXT'` `` so the FQN is resolved at compile time. The guard is now dead under SMW ≥ 7.0 but left intact — scope here is imports, not behaviour.

Also drops two inline-FQN occurrences (`\PHPUnit\Framework\TestCase`, `\Config`) in favour of `use` imports.

## Test plan
- [x] `composer phpunit` — 152 tests, 477 assertions, 7 expected LuaSandbox skips, 0 failures
- [x] `composer analyze` (lint + PHPCS + MinusX) — clean