### PR TITLE
Align MariaDB image and bump docker-compose-ci submodule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
             scribunto_version: REL1_43
             php_version: 8.1
             database_type: mysql
-            database_image: "mariadb:10"
+            database_image: "mariadb:11.2"
             coverage: false
             experimental: false
           - mediawiki_version: '1.43'


### PR DESCRIPTION
## Summary

Two small CI hygiene changes:

* The MW 1.43 / PHP 8.1 matrix entry was the only one still pinned to `mariadb:10`; the other three matrix rows already use `mariadb:11.2`. Aligns all jobs to the same MariaDB version and matches SemanticMediaWiki's convention.
* Bumps the `build` submodule (`gesinn-it-pub/docker-compose-ci`) from `e4652c8` to current upstream `main` (`31d1f9b`). The most relevant change pulled in is `fbec000` (`fix(dockerfile): temp. require ConfigPreloader`), which addresses SMW 7's deprecated `enableSemantics()` path that's been producing the `load.php` MIME warnings in the dev environment. Also picks up Echo extension support and a couple of Makefile/.gitignore fixes.

## Test plan
- [x] CI matrix passes on all four jobs after the bumps