### PR TITLE
Tag Lua queries as inline; validate Lua inputs

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -23,6 +23,13 @@ align with SMW.
   `$smwgQMaxLimit` (default 10000). Wikis that need higher limits in
   Lua-driven reports should raise `$smwgQMaxInlineLimit` in
   `LocalSettings.php`.
+* `mw.smw.ask`, `mw.smw.getQueryResult`, and `mw.smw.info` now raise a
+  Lua error on invalid argument shapes (nested-too-deep tables,
+  non-scalar values, or `nil` where a value is required). Previously
+  the same inputs silently produced empty results or leaked PHP
+  warnings from `processLuaArguments` when `display_errors=On`. Lua
+  modules calling these functions without arguments will now error
+  instead of receiving a degenerate empty response.
 
 ## 2.3.3
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -16,6 +16,13 @@ align with SMW.
   another format whose store result is a string rather than a `QueryResult`).
 * Removed the undocumented `SMW_SCRIBUNTO_VERSION` PHP constant. Dependency
   checks are now handled entirely by `extension.json`'s `requires` block.
+* `mw.smw.ask` and `mw.smw.getQueryResult` now run as inline queries
+  (matching the actual call site inside page parsing) instead of being
+  mis-tagged as special-page queries. The practical effect is that the
+  default result cap is `$smwgQMaxInlineLimit` (default 500) instead of
+  `$smwgQMaxLimit` (default 10000). Wikis that need higher limits in
+  Lua-driven reports should raise `$smwgQMaxInlineLimit` in
+  `LocalSettings.php`.
 
 ## 2.3.3
 

--- a/src/LibraryFactory.php
+++ b/src/LibraryFactory.php
@@ -58,7 +58,7 @@ class LibraryFactory {
 		$query = QueryProcessor::createQuery(
 			$queryString,
 			QueryProcessor::getProcessedParams( $parameters, $printouts ),
-			QueryContext::SPECIAL_PAGE,
+			QueryContext::INLINE_QUERY,
 			'',
 			$printouts
 		);

--- a/src/mw.smw.lua
+++ b/src/mw.smw.lua
@@ -59,6 +59,9 @@ end
 
 -- ask
 function smw.ask( parameters )
+	if not validate( parameters ) then
+		error( 'Invalid parameter type supplied to smw.ask().' )
+	end
 	return php.ask( parameters )
 end
 
@@ -69,6 +72,9 @@ end
 
 -- getQueryResult
 function smw.getQueryResult( queryString )
+	if not validate( queryString ) then
+		error( 'Invalid parameter type supplied to smw.getQueryResult().' )
+	end
 	local queryResult = php.getQueryResult( queryString )
 	if queryResult == nil then return nil end
 	return queryResult
@@ -76,6 +82,12 @@ end
 
 -- info
 function smw.info( text, icon )
+	if not validate_type( text ) then
+		error( 'Invalid parameter type supplied to smw.info() (text must be string/number/boolean/nil).' )
+	end
+	if icon ~= nil and not validate_type( icon ) then
+		error( 'Invalid parameter type supplied to smw.info() (icon must be string/number/boolean/nil).' )
+	end
 	return php.info( text, icon )
 end
 

--- a/tests/phpunit/Integration/JSONScript/Fixtures/module.smw.lua
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/module.smw.lua
@@ -16,6 +16,20 @@ function p.ask( frame )
     return convertResultTableToString( queryResult )
 end
 
+function p.askCount( frame )
+    if not mw.smw then
+        return "mw.smw module not found"
+    end
+    if frame.args[1] == nil then
+        return "no parameter found"
+    end
+    local queryResult = mw.smw.ask( frame.args )
+    if type( queryResult ) ~= 'table' then
+        return "(no values)"
+    end
+    return tostring( #queryResult )
+end
+
 function p.getQueryResult( frame )
 
     if not mw.smw then

--- a/tests/phpunit/Integration/JSONScript/Fixtures/module.smw.lua
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/module.smw.lua
@@ -30,6 +30,19 @@ function p.askCount( frame )
     return tostring( #queryResult )
 end
 
+function p.askInvalid( frame )
+    if not mw.smw then
+        return "mw.smw module not found"
+    end
+    -- Build a table too deep for validate() (3 levels).
+    local badInput = { foo = { bar = { 'too', 'deep' } } }
+    local ok, errMsg = pcall( mw.smw.ask, badInput )
+    if ok then
+        return "expected validate to fail but it did not"
+    end
+    return tostring( errMsg )
+end
+
 function p.getQueryResult( frame )
 
     if not mw.smw then

--- a/tests/phpunit/Integration/JSONScript/TestCases/ask-005-inline-limit.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/ask-005-inline-limit.json
@@ -1,0 +1,53 @@
+{
+	"description": "Test `mw.smw.ask` respects `$smwgQMaxInlineLimit` (regression for QueryContext::INLINE_QUERY fix)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has inline limit text",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "NS_MODULE",
+			"page": "smw",
+			"contents": {
+				"import-from": "/../Fixtures/module.smw.lua"
+			}
+		},
+		{ "page": "Scribunto/ask/005/0", "contents": "[[Has inline limit text::x]] [[Category:ask-005]]" },
+		{ "page": "Scribunto/ask/005/1", "contents": "[[Has inline limit text::x]] [[Category:ask-005]]" },
+		{ "page": "Scribunto/ask/005/2", "contents": "[[Has inline limit text::x]] [[Category:ask-005]]" },
+		{ "page": "Scribunto/ask/005/3", "contents": "[[Has inline limit text::x]] [[Category:ask-005]]" },
+		{ "page": "Scribunto/ask/005/4", "contents": "[[Has inline limit text::x]] [[Category:ask-005]]" },
+		{ "page": "Scribunto/ask/005/5", "contents": "[[Has inline limit text::x]] [[Category:ask-005]]" },
+		{ "page": "Scribunto/ask/005/6", "contents": "[[Has inline limit text::x]] [[Category:ask-005]]" },
+		{ "page": "Scribunto/ask/005/7", "contents": "[[Has inline limit text::x]] [[Category:ask-005]]" },
+		{ "page": "Scribunto/ask/005/8", "contents": "[[Has inline limit text::x]] [[Category:ask-005]]" },
+		{ "page": "Scribunto/ask/005/9", "contents": "[[Has inline limit text::x]] [[Category:ask-005]]" },
+		{
+			"page": "Scribunto/ask/005/Q",
+			"contents": "{{#invoke:smw|askCount|[[Category:ask-005]] [[Has inline limit text::+]]|?#-=page|limit=10000|mainlabel=-}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 inline limit caps result at $smwgQMaxInlineLimit (5), not $smwgQMaxLimit (default 10000)",
+			"subject": "Scribunto/ask/005/Q",
+			"assert-output": {
+				"to-contain": [ "5" ],
+				"not-contain": [ "10", "6" ]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgQMaxInlineLimit": 5,
+		"smwgPageSpecialProperties": [ "_MDAT" ]
+	},
+	"meta": {
+		"version": "1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/set-008.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/set-008.json
@@ -25,7 +25,7 @@
 				"to-contain": [
 					"mw-parser-output",
 					"scribunto-error",
-					"Lua error in mw.smw.lua at line 85: Invalid parameter type supplied to smw.set()."
+					"Lua error in mw.smw.lua at line 97: Invalid parameter type supplied to smw.set()."
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/subobject-003.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/subobject-003.json
@@ -29,7 +29,7 @@
 				"to-contain": [
 					"mw-parser-output",
 					"scribunto-error",
-					"Lua error in mw.smw.lua at line 93: Invalid parameter type supplied to smw.subobject()."
+					"Lua error in mw.smw.lua at line 105: Invalid parameter type supplied to smw.subobject()."
 				]
 			}
 		},
@@ -44,7 +44,7 @@
 				"to-contain": [
 					"mw-parser-output",
 					"scribunto-error",
-					"Lua error in mw.smw.lua at line 96: Invalid type for subobject id supplied to smw.subobject()."
+					"Lua error in mw.smw.lua at line 108: Invalid type for subobject id supplied to smw.subobject()."
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/validate-001.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/validate-001.json
@@ -1,37 +1,37 @@
 {
-    "description": "Test Lua-side validate() rejects too-deeply-nested input for mw.smw.ask",
-    "setup": [
-        {
-            "namespace": "NS_MODULE",
-            "page": "smw",
-            "contents": {
-                "import-from": "/../Fixtures/module.smw.lua"
-            }
-        },
-        {
-            "message-cache": "clear",
-            "page": "Validate/ask/Q",
-            "contents": "{{#invoke:smw|askInvalid}}"
-        }
-    ],
-    "tests": [
-        {
-            "type": "parser",
-            "about": "#0 deeply nested table raises validate error",
-            "subject": "Validate/ask/Q",
-            "assert-output": {
-                "to-contain": [ "Invalid parameter type supplied to smw.ask()" ]
-            }
-        }
-    ],
-    "settings": {
-        "wgContLang": "en",
-        "wgLang": "en",
-        "smwgPageSpecialProperties": [ "_MDAT" ]
-    },
-    "meta": {
-        "version": "1",
-        "is-incomplete": false,
-        "debug": false
-    }
+	"description": "Test Lua-side validate() rejects too-deeply-nested input for mw.smw.ask",
+	"setup": [
+		{
+			"namespace": "NS_MODULE",
+			"page": "smw",
+			"contents": {
+				"import-from": "/../Fixtures/module.smw.lua"
+			}
+		},
+		{
+			"message-cache": "clear",
+			"page": "Validate/ask/Q",
+			"contents": "{{#invoke:smw|askInvalid}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 deeply nested table raises validate error",
+			"subject": "Validate/ask/Q",
+			"assert-output": {
+				"to-contain": [ "Invalid parameter type supplied to smw.ask()" ]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [ "_MDAT" ]
+	},
+	"meta": {
+		"version": "1",
+		"is-incomplete": false,
+		"debug": false
+	}
 }

--- a/tests/phpunit/Integration/JSONScript/TestCases/validate-001.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/validate-001.json
@@ -1,0 +1,37 @@
+{
+    "description": "Test Lua-side validate() rejects too-deeply-nested input for mw.smw.ask",
+    "setup": [
+        {
+            "namespace": "NS_MODULE",
+            "page": "smw",
+            "contents": {
+                "import-from": "/../Fixtures/module.smw.lua"
+            }
+        },
+        {
+            "message-cache": "clear",
+            "page": "Validate/ask/Q",
+            "contents": "{{#invoke:smw|askInvalid}}"
+        }
+    ],
+    "tests": [
+        {
+            "type": "parser",
+            "about": "#0 deeply nested table raises validate error",
+            "subject": "Validate/ask/Q",
+            "assert-output": {
+                "to-contain": [ "Invalid parameter type supplied to smw.ask()" ]
+            }
+        }
+    ],
+    "settings": {
+        "wgContLang": "en",
+        "wgLang": "en",
+        "smwgPageSpecialProperties": [ "_MDAT" ]
+    },
+    "meta": {
+        "version": "1",
+        "is-incomplete": false,
+        "debug": false
+    }
+}

--- a/tests/phpunit/Unit/mw.smw.ask.tests.lua
+++ b/tests/phpunit/Unit/mw.smw.ask.tests.lua
@@ -13,7 +13,7 @@ local testframework = require 'Module:TestFramework'
 local tests = {
 	{ name = 'ask (nil argument)', func = mw.smw.ask,
 		args = { nil },
-		expect = { nil }
+		expect = 'Invalid parameter type supplied to smw.ask().'
 	},
 	{ name = 'ask (no argument)', func = mw.smw.ask,
 		args = { '' },


### PR DESCRIPTION
## Summary

Two correctness fixes for the Lua → Semantic MediaWiki bridge, plus release notes for the user-visible behaviour changes.

### 1. `QueryContext::INLINE_QUERY` for Lua queries (`b44d9f2`)

`LibraryFactory::newQueryResultFrom` was passing `QueryContext::SPECIAL_PAGE` when constructing queries. The Lua bridge is called exclusively from inside page parsing (`{{#invoke:}}`), so it is an inline query by construction — never a special page. The misclassification meant `SMWQuery::setLimit`/`setOffset` applied `$smwgQMaxLimit` (default 10 000) as the result cap rather than the intended `$smwgQMaxInlineLimit` (default 500).

Clean break for 7.0.0: wikis that need higher caps in Lua-driven reports should raise `$smwgQMaxInlineLimit` in `LocalSettings.php`.

### 2. Input validation for `ask` / `getQueryResult` / `info` (`0666b7c`)

Lua-side `validate()` previously only gated `set` and `subobject`. Extending the same defence to `ask`, `getQueryResult`, and `info` means invalid argument shapes (deeply nested tables, non-scalar values, `nil` where a value is required) raise a clear Lua error at the API boundary, where they previously leaked PHP warnings from `processLuaArguments` when `display_errors=On`.

### Notes on scope

An earlier audit finding flagged `mw.smw.info` text escaping as a security issue. Investigation showed SMW's `Highlighter::getContainer` already encodes `<`/`>` in the tooltip body (via `str_replace` after `htmlspecialchars_decode`) and `Html::rawElement` escapes the `title` attribute. No exploitable injection vector through this path, so the change was dropped to avoid a behaviour change with no security benefit.

## Test plan

- [x] `composer analyze` exits 0; no PHPCS warnings on touched files
- [x] New fixture `tests/phpunit/Integration/JSONScript/TestCases/ask-005-inline-limit.json` seeds 10 pages, sets `smwgQMaxInlineLimit=5`, runs `mw.smw.ask{ ..., limit=10000 }`, and asserts the cap is enforced at 5 rather than 10000 (proves the context fix)
- [x] New fixture `tests/phpunit/Integration/JSONScript/TestCases/validate-001.json` asserts deeply-nested Lua input raises the expected error message
- [x] Existing `ask-NNN`, `getQueryResult-NNN`, `info-NNN` fixtures pass unchanged
- [x] Line-number assertions in `set-008.json` / `subobject-003.json` bumped to match new error sites in `mw.smw.lua`
- [x] Each fixture passes individually via `composer phpunit -- --filter <name>`