### PR TITLE
Drop ParserFirstCallInit re-registration workaround

### DIFF
--- a/tests/phpunit/Integration/JSONScript/SemanticScribuntoJsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/SemanticScribuntoJsonTestCaseScriptRunnerTest.php
@@ -2,7 +2,6 @@
 
 namespace SMW\Scribunto\Integration\JSONScript;
 
-use MediaWiki\MediaWikiServices;
 use SMW\Tests\JSONScriptServicesTestCaseRunner;
 use SMW\Tests\JSONScriptTestCaseRunner;
 
@@ -30,29 +29,6 @@ use SMW\Tests\JSONScriptTestCaseRunner;
  * @author mwjames
  */
 class SemanticScribuntoJsonTestCaseScriptRunnerTest extends JSONScriptServicesTestCaseRunner {
-
-	protected function setUp(): void {
-		parent::setUp();
-
-		// SMW's MwHooksHandler::deregisterListedHooks (called from
-		// JSONScriptTestCaseRunner::setUp) issues HookContainer::clear() against
-		// every hook in its list, including ParserFirstCallInit. clear() wipes
-		// ALL handlers for the hook — not just SMW's — and the subsequent
-		// invokeHooksFromRegistry() only restores SMW's. Without this re-register,
-		// Scribunto's #invoke parser function is missing during the test parse
-		// and {{#invoke:...}} renders literally.
-		//
-		// Read the handler spec dynamically from Scribunto's extension.json so
-		// the test stays compatible across MW versions where Scribunto's
-		// constructor service list changes.
-		$services = MediaWikiServices::getInstance();
-		$scribuntoExtJsonPath = $services->getMainConfig()->get( 'ExtensionDirectory' ) . '/Scribunto/extension.json';
-		$scribuntoConfig = json_decode( file_get_contents( $scribuntoExtJsonPath ), true );
-		$pfciHandlerName = $scribuntoConfig['Hooks']['ParserFirstCallInit'];
-		$handlerSpec = $scribuntoConfig['HookHandlers'][$pfciHandlerName];
-		$handler = $services->getObjectFactory()->createObject( $handlerSpec, [ 'allowClassName' => true ] );
-		$services->getHookContainer()->register( 'ParserFirstCallInit', [ $handler, 'onParserFirstCallInit' ] );
-	}
 
 	/**
 	 * @see JSONScriptTestCaseRunner::getRequiredJsonTestCaseMinVersion


### PR DESCRIPTION
## Summary

SemanticMediaWiki [PR #6798](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6798) (merged) fixes the `MwHooksHandler::deregisterListedHooks()` behaviour: it now preserves non-SMW handlers across the clear instead of wiping every handler on shared hooks. With that upstream fix in place, this test class no longer needs to re-register Scribunto's `ParserFirstCallInit` handler in `setUp`.

Removes the workaround introduced under PR #105 (commit `20ea24b`) and resolves the local mirror of [SMW #6797](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6797).

## Test plan
- [x] CI: JSON-script integration tests still pass — `{{#invoke:smw|…}}` should continue to execute (now thanks to the upstream fix preserving Scribunto's handler)