### PR TITLE
Replace the MySQL 9.7 CI leg with MariaDB 11.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             scribunto_version: REL1_44
             php_version: 8.3
             database_type: mysql
-            database_image: "mysql:9.7"
+            database_image: "mariadb:11.8"
             coverage: false
             experimental: false
           - mediawiki_version: '1.45'


### PR DESCRIPTION
## Summary

Follow-up to the per-MW MariaDB LTS matrix: drop the `mysql:9.7` CI leg and run the extension on MariaDB only (`10.11` / `11.4` / `11.8` / `12.3`).

A leaf extension's test suite doesn't exercise the SQLStore paths where MySQL and MariaDB diverge, so the MySQL row added coverage in name only — and SMW core itself does not yet pass on MySQL 9.7. MySQL engine coverage belongs in SMW core's CI, not the extensions.
