### PR TITLE
Drop redundant load_composer_autoloader

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -31,6 +31,5 @@
 			"i18n"
 		]
 	},
-	"load_composer_autoloader": true,
 	"manifest_version": 2
 }


### PR DESCRIPTION
The `extension.json` `load_composer_autoloader` key only `require_once`s the
extension's own `vendor/autoload.php` — a `file_exists`-guarded include, fully
independent of `AutoloadNamespaces`/`AutoloadClasses`. It is only useful when an
extension ships its own third-party Composer dependencies in a local `vendor/`.

SemanticScribunto has no composer `autoload` block and no third-party runtime
Composer dependencies (`require` is `php` + `composer/installers` only;
`composer/installers` is a build-time plugin never loaded at runtime). Its own
classes load via `AutoloadNamespaces` (`SMW\Scribunto\` → `src/`), and the
Scribunto/Semantic MediaWiki dependencies are MediaWiki *extensions*
(`requires.extensions`), not Composer libraries. So the key loads nothing and is
dead weight. This matches the SemanticCompoundQueries end state.

## Verification

Run in the docker-compose-ci container (MediaWiki 1.43, SMW `dev-master`,
Scribunto `REL1_43`), with the key removed:

- `composer analyze` clean (parallel-lint + PHPCS + minus-x).
- `composer phpunit` green — 161 tests, 492 assertions (7 pre-existing
  environment-gated skips).
- Live `eval.php` checks: the extension still loads from the manifest
  (`ExtensionRegistry::isLoaded` true), the `ScribuntoExternalLibraries` hook is
  registered in the real hook container, and `SMW\Scribunto\HooksHandler`
  autoloads via `AutoloadNamespaces`.