### PR TITLE
Use strict semantic versioning for the version number

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,13 +1,8 @@
 This file contains the RELEASE-NOTES of the **Semantic Scribunto** (a.k.a. SSC) extension.
 
-## 7.0.0
+## 3.0.0
 
 Not yet released.
-
-Starting with this release, Semantic Scribunto's major version tracks Semantic
-MediaWiki's major version. Subsequent releases follow the same convention.
-Versions 3.x through 6.x were never released and are intentionally skipped to
-align with SMW.
 
 * Minimum requirement for PHP raised to 8.1.
 * Minimum requirement for MediaWiki raised to 1.43.

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "7.x-dev"
+			"dev-master": "3.x-dev"
 		}
 	},
 	"config": {

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "SemanticScribunto",
-	"version": "7.0.0-alpha",
+	"version": "3.0.0-alpha",
 	"author": [
 		"James Hong Kong",
 		"[https://www.semantic-mediawiki.org/wiki/User:Oetterer Tobias Oetterer]"

--- a/tests/phpunit/Unit/ConvertArrayToLuaTableTest.php
+++ b/tests/phpunit/Unit/ConvertArrayToLuaTableTest.php
@@ -17,7 +17,7 @@ use SMW\Scribunto\ScribuntoLuaLibrary;
  * @group semantic-scribunto
  *
  * @license GPL-2.0-or-later
- * @since 7.0.0
+ * @since 3.0.0
  */
 class ConvertArrayToLuaTableTest extends TestCase {
 


### PR DESCRIPTION
## Summary

Adopt semantic versioning for the **SemanticScribunto** version number. Versioning the extension independently of Semantic MediaWiki lets it introduce its own breaking changes mid-cycle — between Semantic MediaWiki major releases — instead of holding them to realign its major with the next Semantic MediaWiki major.

This sets the version to the extension's own next major, `3.0.0-alpha` (branch-alias `3.x-dev`), rather than tracking the Semantic MediaWiki major. The `SemanticMediaWiki >= 7.0` requirement (the Semantic MediaWiki version this release targets) is unchanged.

## Changes

- `extension.json`: version → `3.0.0-alpha`
- `composer.json`: `extra.branch-alias.dev-master` → `3.x-dev`
- `RELEASE-NOTES.md`: heading → `3.0.0`, and drop the note that described the version tracking / mirroring the Semantic MediaWiki major
- `@since 7.0.0` docblocks updated to `@since 3.0.0` where present
